### PR TITLE
Perbaiki tampilan foto profil admin dan sembunyikan tombol hapus

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -39,6 +39,7 @@ class HandleInertiaRequests extends Middleware
                     'role' => $request->user()->role,
                     'is_admin' => $request->user()->isAdmin(),
                     'is_user' => $request->user()->isUser(),
+                    'profile_photo_url' => $request->user()->profile_photo_url,
                 ] : null,
             ],
             'flash' => [

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -37,6 +37,15 @@ class User extends Authenticatable
     ];
 
     /**
+     * The accessor attributes that should be appended to the model's array form.
+     *
+     * @var array<int, string>
+     */
+    protected $appends = [
+        'profile_photo_url',
+    ];
+
+    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>

--- a/resources/js/pages/admin/users/index.tsx
+++ b/resources/js/pages/admin/users/index.tsx
@@ -169,7 +169,7 @@ export default function Index({ users, filters }: IndexPageProps) {
                                                     <Link href={route('admin.users.edit', user.id)}>Edit</Link>
                                                 </DropdownMenuItem>
                                                 <DropdownMenuItem 
-                                                    className="text-red-600"
+                                                    variant="destructive"
                                                     onClick={() => setDeleteDialog({
                                                         isOpen: true,
                                                         userId: user.id,


### PR DESCRIPTION
Expose `profile_photo_url` in user data and apply destructive styling to the delete action to enable displaying user profile photos and ensure the delete button is clearly visible in the admin users table.

---
<a href="https://cursor.com/background-agent?bcId=bc-871518ad-c6f5-4760-b400-652bf5120926">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-871518ad-c6f5-4760-b400-652bf5120926">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

