### PR TITLE
Perbaiki model chapter dan form admin

### DIFF
--- a/CHAPTER_FIX_NOTES.md
+++ b/CHAPTER_FIX_NOTES.md
@@ -1,0 +1,57 @@
+# Chapter Management Fix Notes
+
+## Issues Found
+
+1. **Model-Form Mismatch**: The Chapter model only had `course_id`, `title`, and `order` fields, but the admin forms were trying to use additional fields: `description`, `duration`, and `is_free`.
+
+2. **Database Schema**: The chapters table was missing columns for the fields used in the forms.
+
+3. **Controller Validation**: The validation rules didn't include the additional fields.
+
+4. **Frontend TypeScript**: Interface definitions weren't consistent with actual data structure.
+
+## Fixes Applied
+
+### 1. Database Migration
+- Created migration: `2025_08_26_000002_add_missing_fields_to_chapters_table.php`
+- Added fields:
+  - `description` (text, nullable)
+  - `duration` (integer, nullable, in minutes)
+  - `is_free` (boolean, default false)
+
+### 2. Model Updates
+- Updated `Chapter.php` model:
+  - Added new fields to `$fillable` array
+  - Added `$casts` for proper data type handling
+
+### 3. Controller Updates
+- Updated `ChapterController.php`:
+  - Added validation rules for new fields in `store()` and `update()` methods
+  - Made `description` and `duration` nullable
+  - Added `is_free` as boolean validation
+
+### 4. Frontend Fixes
+- Updated TypeScript interfaces in all chapter pages
+- Fixed field references (e.g., `materials_count` → `course_materials_count`)
+- Added null/undefined handling for optional fields
+- Enhanced the show page to display new fields
+
+## How to Apply
+
+1. Run the migration:
+   ```bash
+   php artisan migrate
+   ```
+
+2. The forms should now work properly with all fields being saved to the database.
+
+## Fields Summary
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| course_id | integer | Yes | Foreign key to courses table |
+| title | string | Yes | Chapter title |
+| description | text | No | Chapter description |
+| order | integer | Yes | Chapter order/position |
+| duration | integer | No | Duration in minutes |
+| is_free | boolean | No | Whether chapter is free (default: false) |

--- a/app/Http/Controllers/Admin/ChapterController.php
+++ b/app/Http/Controllers/Admin/ChapterController.php
@@ -45,7 +45,10 @@ class ChapterController extends Controller
         $validated = $request->validate([
             'course_id' => 'required|exists:courses,id',
             'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
             'order' => 'required|integer|min:1',
+            'duration' => 'nullable|integer|min:1',
+            'is_free' => 'boolean',
         ]);
 
         Chapter::create($validated);
@@ -73,7 +76,10 @@ class ChapterController extends Controller
         $validated = $request->validate([
             'course_id' => 'required|exists:courses,id',
             'title' => 'required|string|max:255',
+            'description' => 'nullable|string',
             'order' => 'required|integer|min:1',
+            'duration' => 'nullable|integer|min:1',
+            'is_free' => 'boolean',
         ]);
 
         $chapter->update($validated);

--- a/app/Models/Chapter.php
+++ b/app/Models/Chapter.php
@@ -14,7 +14,15 @@ class Chapter extends Model
     protected $fillable = [
         'course_id',
         'title',
+        'description',
         'order',
+        'duration',
+        'is_free',
+    ];
+
+    protected $casts = [
+        'is_free' => 'boolean',
+        'duration' => 'integer',
     ];
 
     /**

--- a/database/migrations/2025_08_26_000002_add_missing_fields_to_chapters_table.php
+++ b/database/migrations/2025_08_26_000002_add_missing_fields_to_chapters_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('chapters', function (Blueprint $table) {
+            $table->text('description')->nullable()->after('title');
+            $table->integer('duration')->nullable()->comment('Duration in minutes')->after('description');
+            $table->boolean('is_free')->default(false)->after('duration');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('chapters', function (Blueprint $table) {
+            $table->dropColumn(['description', 'duration', 'is_free']);
+        });
+    }
+};

--- a/resources/js/pages/admin/chapters/index.tsx
+++ b/resources/js/pages/admin/chapters/index.tsx
@@ -33,13 +33,13 @@ interface Course {
 interface Chapter {
     id: number;
     title: string;
-    description: string;
+    description?: string;
     order: number;
-    duration: number; // in minutes
-    is_free: boolean;
+    duration?: number; // in minutes
+    is_free?: boolean;
     created_at: string;
     course: Course;
-    materials_count: number;
+    course_materials_count: number;
 }
 
 interface ChaptersProps extends PageProps {
@@ -193,9 +193,11 @@ export default function Chapters({ chapters, courses }: ChaptersProps) {
                                     <TableCell>
                                         <div>
                                             <div className="font-medium">{chapter.title}</div>
-                                            <div className="text-sm text-muted-foreground line-clamp-1">
-                                                {chapter.description}
-                                            </div>
+                                            {chapter.description && (
+                                                <div className="text-sm text-muted-foreground line-clamp-1">
+                                                    {chapter.description}
+                                                </div>
+                                            )}
                                         </div>
                                     </TableCell>
                                     <TableCell>
@@ -207,14 +209,16 @@ export default function Chapters({ chapters, courses }: ChaptersProps) {
                                     <TableCell>
                                         <div className="flex items-center gap-1">
                                             <Clock className="h-4 w-4 text-muted-foreground" />
-                                            <span className="text-sm">{formatDuration(chapter.duration)}</span>
+                                            <span className="text-sm">
+                                                {chapter.duration ? formatDuration(chapter.duration) : '-'}
+                                            </span>
                                         </div>
                                     </TableCell>
                                     <TableCell>
                                         <div className="flex items-center gap-1">
                                             <FileText className="h-4 w-4 text-muted-foreground" />
                                             <Badge variant="secondary" className="text-xs">
-                                                {chapter.materials_count} materi
+                                                {chapter.course_materials_count} materi
                                             </Badge>
                                         </div>
                                     </TableCell>
@@ -286,7 +290,7 @@ export default function Chapters({ chapters, courses }: ChaptersProps) {
                     </CardHeader>
                     <CardContent>
                         <div className="text-2xl font-bold">
-                            {formatDuration(chapters.data.reduce((acc, chapter) => acc + chapter.duration, 0))}
+                            {formatDuration(chapters.data.reduce((acc, chapter) => acc + (chapter.duration || 0), 0))}
                         </div>
                         <p className="text-xs text-muted-foreground">
                             Total durasi semua chapter

--- a/resources/js/pages/admin/chapters/show.tsx
+++ b/resources/js/pages/admin/chapters/show.tsx
@@ -22,6 +22,8 @@ interface ChapterShowProps extends PageProps {
 		title: string;
 		description?: string;
 		order: number;
+		duration?: number;
+		is_free?: boolean;
 		course: Course;
 		course_materials: Material[];
 	};
@@ -54,13 +56,25 @@ export default function ChapterShow({ chapter }: ChapterShowProps) {
 							<BookOpen className="h-5 w-5" />
 							{chapter.title}
 							<Badge variant="secondary">Chapter {chapter.order}</Badge>
+							{chapter.is_free && <Badge variant="default">Gratis</Badge>}
 						</CardTitle>
 					</CardHeader>
 					<CardContent className="space-y-3">
 						<div className="text-sm text-muted-foreground">Kursus: {chapter.course.title}</div>
+						{chapter.duration && (
+							<div className="text-sm text-muted-foreground">
+								Durasi: {Math.floor(chapter.duration / 60) > 0 && `${Math.floor(chapter.duration / 60)}h `}{chapter.duration % 60}m
+							</div>
+						)}
 						{chapter.description && (
 							<p className="text-muted-foreground">{chapter.description}</p>
 						)}
+						<div className="flex items-center gap-4 text-sm">
+							<span className="text-muted-foreground">Status:</span>
+							<Badge variant={chapter.is_free ? "default" : "secondary"}>
+								{chapter.is_free ? "Chapter Gratis" : "Chapter Premium"}
+							</Badge>
+						</div>
 					</CardContent>
 				</Card>
 


### PR DESCRIPTION
Align Chapter model and admin forms by adding missing fields and updating validation and frontend interfaces.

The admin forms for managing chapters were attempting to use `description`, `duration`, and `is_free` fields which were not present in the `Chapter` model or database schema. This PR resolves the mismatch by introducing these fields, updating the model's fillable and cast properties, adding validation rules in the controller, and ensuring frontend TypeScript interfaces and UI components correctly handle and display these new (and now optional) fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbc15167-997c-4dfd-a92c-49f54aa2bf42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbc15167-997c-4dfd-a92c-49f54aa2bf42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

