### PR TITLE
Perbaiki error qs tidak terdefinisi di admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
                 "globals": "^15.14.0",
                 "laravel-vite-plugin": "^2.0",
                 "lucide-react": "^0.475.0",
+                "qs": "^6.14.0",
                 "react": "^19.0.0",
                 "react-chartjs-2": "^5.3.0",
                 "react-dom": "^19.0.0",
@@ -49,6 +50,7 @@
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
                 "@types/node": "^22.13.5",
+                "@types/qs": "^6.14.0",
                 "concurrently": "^9.2.1",
                 "eslint": "^9.17.0",
                 "eslint-config-prettier": "^10.0.1",
@@ -2915,6 +2917,13 @@
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
+        },
+        "node_modules/@types/qs": {
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+            "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "19.1.10",
@@ -6353,6 +6362,7 @@
             "version": "6.14.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
             "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+            "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
             },

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "devDependencies": {
         "@eslint/js": "^9.19.0",
         "@types/node": "^22.13.5",
+        "@types/qs": "^6.14.0",
         "concurrently": "^9.2.1",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
@@ -56,6 +57,7 @@
         "globals": "^15.14.0",
         "laravel-vite-plugin": "^2.0",
         "lucide-react": "^0.475.0",
+        "qs": "^6.14.0",
         "react": "^19.0.0",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",

--- a/resources/js/pages/admin/users/index.tsx
+++ b/resources/js/pages/admin/users/index.tsx
@@ -23,6 +23,7 @@ import { Head, Link, router } from '@inertiajs/react';
 import { MoreHorizontal, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { AdminFilter, FilterConfig } from '@/components/admin/AdminFilter';
+import qs from 'qs';
 
 type IndexPageProps = {
     users: {


### PR DESCRIPTION
Fix `ReferenceError: qs is not defined` in the admin users page by importing `qs` and adding it to dependencies.

---
<a href="https://cursor.com/background-agent?bcId=bc-426243b7-72a1-497c-ade0-fa56a11723aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-426243b7-72a1-497c-ade0-fa56a11723aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

