### PR TITLE
Fix admin global search redirection

### DIFF
--- a/resources/js/components/global-search.tsx
+++ b/resources/js/components/global-search.tsx
@@ -180,7 +180,7 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
                         title: user.name,
                         description: user.email,
                         type: 'user',
-                        url: route('admin.users.show', { user: user.id }),
+                        url: route('admin.users.edit', { user: user.id }),
                         icon: <Users className="h-4 w-4" />,
                         meta: user.role,
                     });
@@ -367,6 +367,7 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
                                         <CommandItem
                                             key={result.id}
                                             className="flex items-center gap-3 px-3 py-2 cursor-pointer"
+                                            value={result.title}
                                             onSelect={() => handleSelect(result)}
                                         >
                                             <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">
@@ -398,6 +399,7 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
                                                     <CommandItem
                                                         key={result.id}
                                                         className="flex items-center gap-3 px-3 py-2 cursor-pointer"
+                                                        value={result.title}
                                                         onSelect={() => handleSelect(result)}
                                                     >
                                                         <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">
@@ -422,6 +424,7 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
                                             <CommandItem
                                                 key={item.id}
                                                 className="flex items-center gap-3 px-3 py-2 cursor-pointer"
+                                                value={item.title}
                                                 onSelect={() => handleSelect(item)}
                                             >
                                                 <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">


### PR DESCRIPTION
Fix admin global search result navigation for users and ensure reliable CommandItem selection.

User results in the admin global search were incorrectly routed to `admin.users.show`, which was not implemented, preventing navigation. This PR updates the route to `admin.users.edit` and adds `value` props to `CommandItem` components to ensure their `onSelect` events trigger as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-011852ae-ef7d-4930-b0a0-2697b9d5a094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-011852ae-ef7d-4930-b0a0-2697b9d5a094">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

