### PR TITLE
Fix unclickable admin global search results

### DIFF
--- a/resources/js/components/global-search.tsx
+++ b/resources/js/components/global-search.tsx
@@ -299,6 +299,8 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
     }, [searchQuery]);
 
     const handleSelect = (result: SearchResult) => {
+        console.log('handleSelect called with:', result);
+        
         // Save to recent searches
         const newRecent = [result, ...recentSearches.filter(r => r.id !== result.id)].slice(0, 5);
         setRecentSearches(newRecent);
@@ -317,12 +319,17 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
         
         // Navigate to the result with error handling
         try {
+            console.log('Navigating to:', result.url);
             router.visit(result.url, {
                 preserveState: false,
                 preserveScroll: false,
                 onError: (errors) => {
                     console.error('Navigation error:', errors);
-                    // Optionally show user-friendly error message
+                    // Fallback: try direct window navigation
+                    window.location.href = result.url;
+                },
+                onSuccess: () => {
+                    console.log('Navigation successful');
                 }
             });
         } catch (error) {
@@ -393,9 +400,10 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
                                     {searchResults.map((result) => (
                                         <CommandItem
                                             key={result.id}
-                                            className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-accent/50 transition-colors"
+                                            className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors data-[selected]:bg-accent data-[selected]:text-accent-foreground"
                                             value={result.title}
                                             onSelect={() => handleSelect(result)}
+                                            onClick={() => handleSelect(result)}
                                         >
                                             <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">
                                                 {result.icon}
@@ -425,9 +433,10 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
                                                 {recentSearches.map((result) => (
                                                     <CommandItem
                                                         key={result.id}
-                                                        className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-accent/50 transition-colors"
+                                                        className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors data-[selected]:bg-accent data-[selected]:text-accent-foreground"
                                                         value={result.title}
                                                         onSelect={() => handleSelect(result)}
+                                                        onClick={() => handleSelect(result)}
                                                     >
                                                         <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">
                                                             <Clock className="h-4 w-4" />
@@ -450,9 +459,10 @@ export function GlobalSearch({ isOpen: controlledIsOpen, onClose, trigger }: Glo
                                         {quickAccess.map((item) => (
                                             <CommandItem
                                                 key={item.id}
-                                                className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-accent/50 transition-colors"
+                                                className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-accent hover:text-accent-foreground transition-colors data-[selected]:bg-accent data-[selected]:text-accent-foreground"
                                                 value={item.title}
                                                 onSelect={() => handleSelect(item)}
+                                                onClick={() => handleSelect(item)}
                                             >
                                                 <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted">
                                                     {item.icon}

--- a/resources/js/components/ui/command.tsx
+++ b/resources/js/components/ui/command.tsx
@@ -115,7 +115,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none aria-selected:bg-accent aria-selected:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}


### PR DESCRIPTION
Fix unclickable admin global search results by adding `onClick` handlers and improving cursor feedback.

The previous implementation relied primarily on `onSelect` for `CommandItem`s, which handles keyboard navigation. This PR adds explicit `onClick` handlers to ensure mouse clicks are also registered. Additionally, the cursor is changed from `default` to `pointer` and hover/selected styles are refined to provide clear visual cues for clickable elements, improving user experience. Enhanced error handling and a fallback navigation mechanism were also added for robustness.

---
<a href="https://cursor.com/background-agent?bcId=bc-c39f8a64-d90c-4676-bd86-f5da8e7fa144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c39f8a64-d90c-4676-bd86-f5da8e7fa144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

