### PR TITLE
Perbaiki penanganan rute dan tampilkan halaman error kustom

### DIFF
--- a/app/Http/Middleware/HandlePrefixRedirect.php
+++ b/app/Http/Middleware/HandlePrefixRedirect.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+use Symfony\Component\HttpFoundation\Response;
+
+class HandlePrefixRedirect
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $path = $request->path();
+        $segments = explode('/', trim($path, '/'));
+        
+        // Define prefix redirects
+        $prefixRedirects = [
+            'admin' => 'admin.dashboard',
+            'user' => 'user.dashboard',
+        ];
+        
+        // Check if path is exactly a prefix (e.g., /admin or /user)
+        if (count($segments) === 1 && isset($prefixRedirects[$segments[0]])) {
+            $routeName = $prefixRedirects[$segments[0]];
+            if (Route::has($routeName)) {
+                return redirect()->route($routeName);
+            }
+        }
+        
+        // Check if the current route exists
+        $routeExists = false;
+        try {
+            $route = $request->route();
+            if ($route) {
+                $routeExists = true;
+            }
+        } catch (\Exception $e) {
+            $routeExists = false;
+        }
+        
+        // If route doesn't exist but has a valid prefix, check for redirect
+        if (!$routeExists && count($segments) > 0) {
+            $prefix = $segments[0];
+            
+            // Check if this is a valid prefix that should redirect to dashboard
+            if (isset($prefixRedirects[$prefix])) {
+                $routeName = $prefixRedirects[$prefix];
+                if (Route::has($routeName)) {
+                    // Check if user has permission to access this prefix
+                    if ($this->hasAccessToPrefix($prefix, $request)) {
+                        return redirect()->route($routeName);
+                    }
+                }
+            }
+        }
+        
+        return $next($request);
+    }
+    
+    /**
+     * Check if user has access to the given prefix
+     */
+    private function hasAccessToPrefix(string $prefix, Request $request): bool
+    {
+        $user = $request->user();
+        
+        if (!$user) {
+            return false;
+        }
+        
+        switch ($prefix) {
+            case 'admin':
+                return $user->isAdmin();
+            case 'user':
+                return $user->isUser();
+            default:
+                return false;
+        }
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\CorsMiddleware;
+use App\Http\Middleware\HandlePrefixRedirect;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -26,6 +27,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->web(append: [
             HandleAppearance::class,
+            HandlePrefixRedirect::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
         ]);
@@ -38,6 +40,59 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->redirectGuestsTo('/login');
     })
     ->withExceptions(function (Exceptions $exceptions) {
+        // Handle NotFoundHttpException (404 errors)
+        $exceptions->render(function (NotFoundHttpException $e, $request) {
+            if ($request->wantsJson() || $request->inertia()) {
+                return Inertia::render('errors/404', [
+                    'status' => 404
+                ])->toResponse($request)->setStatusCode(404);
+            }
+        });
+        
+        // Handle AuthenticationException
+        $exceptions->render(function (AuthenticationException $e, $request) {
+            if ($request->wantsJson() || $request->inertia()) {
+                return Inertia::render('errors/403', [
+                    'status' => 403,
+                    'message' => 'Unauthenticated.'
+                ])->toResponse($request)->setStatusCode(403);
+            }
+        });
+        
+        // Handle any HttpException (403, 419, 500, 503, etc.)
+        $exceptions->render(function (HttpException $e, $request) {
+            if ($request->wantsJson() || $request->inertia()) {
+                $statusCode = $e->getStatusCode();
+                $customErrorPages = [403, 404, 419, 500, 503];
+                
+                // Use specific error page if available
+                if (in_array($statusCode, $customErrorPages)) {
+                    return Inertia::render('errors/' . $statusCode, [
+                        'status' => $statusCode
+                    ])->toResponse($request)->setStatusCode($statusCode);
+                }
+                
+                // For other HTTP errors, use the generic error page
+                return Inertia::render('errors/index', [
+                    'status' => $statusCode,
+                    'message' => $e->getMessage() ?: null
+                ])->toResponse($request)->setStatusCode($statusCode);
+            }
+        });
+        
+        // Handle any other exception
+        $exceptions->render(function (\Throwable $e, $request) {
+            if ($request->wantsJson() || $request->inertia()) {
+                // In production, don't expose internal errors
+                $isDebug = config('app.debug');
+                
+                return Inertia::render('errors/500', [
+                    'status' => 500,
+                    'message' => $isDebug ? $e->getMessage() : 'Server Error'
+                ])->toResponse($request)->setStatusCode(500);
+            }
+        });
+        
         $exceptions->respond(function ($response, $exception, $request) {
             // List of error codes we have custom pages for
             $customErrorPages = [403, 404, 419, 500, 503];

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -16,6 +16,11 @@ use Illuminate\Support\Facades\Route;
 
 // Routes untuk Admin
 Route::middleware(['auth', 'verified', 'role:admin'])->prefix('admin')->name('admin.')->group(function () {
+    // Redirect /admin to /admin/dashboard
+    Route::get('/', function () {
+        return redirect()->route('admin.dashboard');
+    });
+    
     Route::get('/dashboard', [AdminController::class, 'index'])->name('dashboard');
     Route::get('/dashboard/export', [AdminController::class, 'export'])->name('dashboard.export');
     

--- a/routes/test-redirect.php
+++ b/routes/test-redirect.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Inertia\Inertia;
+
+/**
+ * Test routes untuk memverifikasi redirect dan error handling
+ * 
+ * Test scenarios:
+ * 1. /admin -> redirect ke /admin/dashboard
+ * 2. /user -> redirect ke /user/dashboard  
+ * 3. /admin/nonexistent -> custom 404 page
+ * 4. /user/kocak -> custom 404 page
+ * 5. /random/path -> custom 404 page
+ */
+
+// Test untuk memverifikasi behavior
+Route::get('/test-redirects', function () {
+    $tests = [
+        [
+            'url' => '/admin',
+            'expected' => 'Redirect to /admin/dashboard (if authenticated as admin)',
+            'description' => 'Accessing /admin should redirect to admin dashboard'
+        ],
+        [
+            'url' => '/user', 
+            'expected' => 'Redirect to /user/dashboard (if authenticated as user)',
+            'description' => 'Accessing /user should redirect to user dashboard'
+        ],
+        [
+            'url' => '/admin/nonexistent',
+            'expected' => 'Custom 404 error page',
+            'description' => 'Non-existent admin route should show custom 404'
+        ],
+        [
+            'url' => '/user/kocak',
+            'expected' => 'Custom 404 error page',
+            'description' => 'Non-existent user route should show custom 404'
+        ],
+        [
+            'url' => '/random/path/here',
+            'expected' => 'Custom 404 error page',
+            'description' => 'Random path should show custom 404'
+        ]
+    ];
+    
+    return response()->json([
+        'message' => 'Redirect and Error Handling Test Cases',
+        'tests' => $tests,
+        'note' => 'Access each URL to test the behavior'
+    ]);
+});

--- a/routes/user.php
+++ b/routes/user.php
@@ -5,6 +5,11 @@ use Illuminate\Support\Facades\Route;
 
 // Routes untuk User
 Route::middleware(['auth', 'verified', 'role:user'])->prefix('user')->name('user.')->group(function () {
+    // Redirect /user to /user/dashboard
+    Route::get('/', function () {
+        return redirect()->route('user.dashboard');
+    });
+    
     Route::get('/dashboard', [UserController::class, 'dashboard'])->name('dashboard');
     Route::get('/profile', [UserController::class, 'profile'])->name('profile');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,6 +47,9 @@ if (app()->environment('local')) {
     Route::get('/test-419', function () {
         abort(419);
     });
+    
+    // Include test redirect routes
+    require __DIR__ . '/test-redirect.php';
 }
 
 require __DIR__ . '/auth.php';
@@ -54,9 +57,33 @@ require __DIR__ . '/settings.php';
 require __DIR__ . '/admin.php';
 require __DIR__ . '/user.php';
 
-// Fallback route untuk menangani 404 - harus di paling bawah
-Route::fallback(function () {
+// Catch all route for handling 404 and undefined routes
+// This must be at the very bottom of all routes
+Route::any('/{any}', function () {
+    // Check if user is authenticated and trying to access admin/user routes
+    $path = request()->path();
+    $segments = explode('/', trim($path, '/'));
+    
+    if (auth()->check() && count($segments) > 0) {
+        $prefix = $segments[0];
+        
+        // If user is trying to access admin routes but doesn't have permission
+        if ($prefix === 'admin' && !auth()->user()->isAdmin()) {
+            return Inertia::render('errors/403', [
+                'status' => 403,
+                'message' => 'You do not have permission to access this area.'
+            ]);
+        }
+        
+        // If admin is trying to access user routes
+        if ($prefix === 'user' && auth()->user()->isAdmin()) {
+            return redirect()->route('admin.dashboard');
+        }
+    }
+    
+    // Return 404 for all other cases
     return Inertia::render('errors/404', [
-        'status' => 404
+        'status' => 404,
+        'message' => 'The page you are looking for could not be found.'
     ]);
-});
+})->where('any', '.*')->name('fallback');


### PR DESCRIPTION
Implement prefix redirects and custom Inertia error page handling to improve user experience and prevent exposure of internal server errors.

Previously, accessing a route prefix like `/admin` without a specific path would not redirect to the dashboard, and undefined routes (e.g., `/admin/user/kocak`) would display a generic "Undefined variable $page" error. This PR introduces a middleware for automatic prefix redirection and enhances the global exception handler to consistently render custom Inertia error pages (404, 403, 500) for all unhandled routes and exceptions.

---
<a href="https://cursor.com/background-agent?bcId=bc-92fbac1d-f805-44ed-a1fb-dbd332965475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92fbac1d-f805-44ed-a1fb-dbd332965475">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

