### PR TITLE
Apply shadcn ui styling to auth components

### DIFF
--- a/resources/js/components/input-error.tsx
+++ b/resources/js/components/input-error.tsx
@@ -3,7 +3,7 @@ import { type HTMLAttributes } from 'react';
 
 export default function InputError({ message, className = '', ...props }: HTMLAttributes<HTMLParagraphElement> & { message?: string }) {
     return message ? (
-        <p {...props} className={cn('text-sm text-red-600 dark:text-red-400', className)}>
+        <p {...props} className={cn('text-sm text-destructive', className)}>
             {message}
         </p>
     ) : null;

--- a/resources/js/components/text-link.tsx
+++ b/resources/js/components/text-link.tsx
@@ -8,7 +8,7 @@ export default function TextLink({ className = '', children, ...props }: LinkPro
     return (
         <Link
             className={cn(
-                'text-foreground underline decoration-neutral-300 underline-offset-4 transition-colors duration-300 ease-out hover:decoration-current! dark:decoration-neutral-500',
+                'font-medium text-primary underline-offset-4 hover:underline',
                 className,
             )}
             {...props}

--- a/resources/js/layouts/auth-layout.tsx
+++ b/resources/js/layouts/auth-layout.tsx
@@ -1,9 +1,21 @@
-import AuthLayoutTemplate from '@/layouts/auth/auth-simple-layout';
+import AuthCardLayout from '@/layouts/auth/auth-card-layout';
 
-export default function AuthLayout({ children, title, description, ...props }: { children: React.ReactNode; title: string; description: string }) {
+export default function AuthLayout({ 
+    children, 
+    title, 
+    description, 
+    variant = 'card',
+    ...props 
+}: { 
+    children: React.ReactNode; 
+    title: string; 
+    description?: string;
+    variant?: 'simple' | 'card' | 'split';
+}) {
+    // Default to card layout for better shadcn/ui consistency
     return (
-        <AuthLayoutTemplate title={title} description={description} {...props}>
+        <AuthCardLayout title={title} description={description} {...props}>
             {children}
-        </AuthLayoutTemplate>
+        </AuthCardLayout>
     );
 }

--- a/resources/js/layouts/auth/auth-card-layout.tsx
+++ b/resources/js/layouts/auth/auth-card-layout.tsx
@@ -13,23 +13,27 @@ export default function AuthCardLayout({
     description?: string;
 }>) {
     return (
-        <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-muted p-6 md:p-10">
-            <div className="flex w-full max-w-md flex-col gap-6">
-                <Link href={route('home')} className="flex items-center gap-2 self-center font-medium">
-                    <div className="flex h-9 w-9 items-center justify-center">
-                        <AppLogoIcon className="size-9 fill-current text-black dark:text-white" />
-                    </div>
-                </Link>
-
-                <div className="flex flex-col gap-6">
-                    <Card className="rounded-xl">
-                        <CardHeader className="px-10 pt-8 pb-0 text-center">
-                            <CardTitle className="text-xl">{title}</CardTitle>
-                            <CardDescription>{description}</CardDescription>
-                        </CardHeader>
-                        <CardContent className="px-10 py-8">{children}</CardContent>
-                    </Card>
+        <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6 md:p-10">
+            <div className="w-full max-w-md space-y-6">
+                <div className="flex flex-col items-center space-y-2">
+                    <Link href={route('home')} className="flex items-center space-x-2">
+                        <AppLogoIcon className="h-8 w-8" />
+                        <span className="text-2xl font-semibold">Pare EduHub</span>
+                    </Link>
+                    <p className="text-sm text-muted-foreground">Platform Kursus Online</p>
                 </div>
+
+                <Card>
+                    <CardHeader className="space-y-1">
+                        <CardTitle className="text-2xl text-center">{title}</CardTitle>
+                        {description && (
+                            <CardDescription className="text-center">
+                                {description}
+                            </CardDescription>
+                        )}
+                    </CardHeader>
+                    <CardContent>{children}</CardContent>
+                </Card>
             </div>
         </div>
     );

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -10,52 +10,31 @@ interface AuthLayoutProps {
 
 export default function AuthSimpleLayout({ children, title, description }: PropsWithChildren<AuthLayoutProps>) {
     return (
-        <div className="relative flex min-h-svh flex-col items-center justify-center bg-gradient-to-br from-primary/10 via-background to-primary/5 p-6 md:p-10">
-            {/* Background decorative elements */}
-            <div className="absolute inset-0 overflow-hidden">
-                <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 blur-3xl"></div>
-                <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-gradient-to-tr from-primary/20 to-primary/10 blur-3xl"></div>
-            </div>
-
-            <div className="relative w-full max-w-md">
-                <div className="rounded-2xl border border-white/20 bg-white/80 p-8 shadow-2xl backdrop-blur-xl dark:border-slate-800/50 dark:bg-slate-900/80 dark:shadow-slate-900/50">
-                    <div className="flex flex-col gap-8">
-                        {/* Logo and branding section */}
-                        <div className="flex flex-col items-center gap-6">
-                            <Link href={route('home')} className="group flex flex-col items-center gap-3 transition-all duration-300 hover:scale-105">
-                                <div className="relative">
-                                    <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-primary/20 to-primary/10 blur-xl transition-all duration-300 group-hover:from-primary/30 group-hover:to-primary/20"></div>
-                                    <div className="relative flex h-24 w-24 items-center justify-center rounded-2xl bg-gradient-to-br from-white to-slate-50 shadow-lg ring-1 ring-slate-200/50 transition-all duration-300 group-hover:shadow-xl dark:from-slate-800 dark:to-slate-700 dark:ring-slate-700/50">
-                                        <AppLogoIcon className="h-16 w-16 transition-transform duration-300 group-hover:scale-110" />
-                                    </div>
-                                </div>
-                                <div className="text-center">
-                                    <h2 className="text-xl font-bold bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
-                                        Pare EduHub
-                                    </h2>
-                                    <p className="text-sm text-muted-foreground">Platform Kursus Online</p>
-                                </div>
-                                <span className="sr-only">{title}</span>
-                            </Link>
-
-                            {/* Title and description */}
-                            <div className="space-y-3 text-center">
-                                <h1 className="bg-gradient-to-r from-slate-900 to-slate-600 bg-clip-text text-2xl font-bold text-transparent dark:from-white dark:to-slate-300">
-                                    {title}
-                                </h1>
-                                {description && <p className="text-sm leading-relaxed text-slate-600 dark:text-slate-400">{description}</p>}
-                            </div>
-                        </div>
-
-                        {/* Content section */}
-                        <div className="space-y-4">{children}</div>
-                    </div>
+        <div className="flex min-h-screen flex-col items-center justify-center bg-background p-6 md:p-10">
+            <div className="w-full max-w-md space-y-8">
+                {/* Logo and branding section */}
+                <div className="flex flex-col items-center space-y-2">
+                    <Link href={route('home')} className="flex items-center space-x-2">
+                        <AppLogoIcon className="h-8 w-8" />
+                        <span className="text-2xl font-semibold">Pare EduHub</span>
+                    </Link>
+                    <p className="text-sm text-muted-foreground">Platform Kursus Online</p>
                 </div>
 
-                {/* Footer decoration */}
-                <div className="mt-8 text-center">
-                    <p className="text-xs text-slate-500 dark:text-slate-400">Secure • Reliable • Fast</p>
+                {/* Title and description */}
+                <div className="space-y-2 text-center">
+                    <h1 className="text-2xl font-semibold tracking-tight">
+                        {title}
+                    </h1>
+                    {description && (
+                        <p className="text-sm text-muted-foreground">
+                            {description}
+                        </p>
+                    )}
                 </div>
+
+                {/* Content section */}
+                <div>{children}</div>
             </div>
         </div>
     );

--- a/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/resources/js/layouts/auth/auth-split-layout.tsx
@@ -12,30 +12,37 @@ export default function AuthSplitLayout({ children, title, description }: PropsW
     const { name, quote } = usePage<SharedData>().props;
 
     return (
-        <div className="relative grid h-dvh flex-col items-center justify-center px-8 sm:px-0 lg:max-w-none lg:grid-cols-2 lg:px-0">
-            <div className="relative hidden h-full flex-col bg-muted p-10 text-white lg:flex dark:border-r">
-                <div className="absolute inset-0 bg-zinc-900" />
+        <div className="relative grid min-h-screen lg:grid-cols-2">
+            {/* Left side panel */}
+            <div className="relative hidden flex-col bg-muted p-10 text-muted-foreground lg:flex">
                 <Link href={route('home')} className="relative z-20 flex items-center text-lg font-medium">
-                    <AppLogoIcon className="mr-2 size-8 fill-current text-white" />
-                    {name}
+                    <AppLogoIcon className="mr-2 h-6 w-6" />
+                    <span className="font-semibold">{name || 'Pare EduHub'}</span>
                 </Link>
                 {quote && (
                     <div className="relative z-20 mt-auto">
                         <blockquote className="space-y-2">
                             <p className="text-lg">&ldquo;{quote.message}&rdquo;</p>
-                            <footer className="text-sm text-neutral-300">{quote.author}</footer>
+                            <footer className="text-sm">{quote.author}</footer>
                         </blockquote>
                     </div>
                 )}
             </div>
-            <div className="w-full lg:p-8">
+            
+            {/* Right side content */}
+            <div className="flex items-center justify-center p-8">
                 <div className="mx-auto flex w-full flex-col justify-center space-y-6 sm:w-[350px]">
-                    <Link href={route('home')} className="relative z-20 flex items-center justify-center lg:hidden">
-                        <AppLogoIcon className="h-10 fill-current text-black sm:h-12" />
-                    </Link>
-                    <div className="flex flex-col items-start gap-2 text-left sm:items-center sm:text-center">
-                        <h1 className="text-xl font-medium">{title}</h1>
-                        <p className="text-sm text-balance text-muted-foreground">{description}</p>
+                    <div className="flex flex-col items-center space-y-2 lg:hidden">
+                        <Link href={route('home')} className="flex items-center space-x-2">
+                            <AppLogoIcon className="h-8 w-8" />
+                            <span className="text-2xl font-semibold">Pare EduHub</span>
+                        </Link>
+                    </div>
+                    <div className="flex flex-col space-y-2 text-center">
+                        <h1 className="text-2xl font-semibold tracking-tight">{title}</h1>
+                        {description && (
+                            <p className="text-sm text-muted-foreground">{description}</p>
+                        )}
                     </div>
                     {children}
                 </div>

--- a/resources/js/pages/auth/demo.tsx
+++ b/resources/js/pages/auth/demo.tsx
@@ -1,0 +1,101 @@
+import { Head, Link } from '@inertiajs/react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function AuthDemo() {
+    return (
+        <div className="min-h-screen bg-background p-8">
+            <Head title="Auth Layout Demo" />
+            
+            <div className="mx-auto max-w-4xl space-y-8">
+                <div className="text-center">
+                    <h1 className="text-3xl font-bold">Auth Layout Demo</h1>
+                    <p className="mt-2 text-muted-foreground">
+                        Tampilan auth dengan style shadcn/ui yang bersih tanpa warna custom
+                    </p>
+                </div>
+
+                <div className="grid gap-6 md:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Simple Layout</CardTitle>
+                            <CardDescription>
+                                Layout sederhana tanpa card, cocok untuk halaman minimal
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <Link href="/auth/demo/simple">
+                                <Button className="w-full" variant="outline">
+                                    Lihat Simple Layout
+                                </Button>
+                            </Link>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Card Layout (Default)</CardTitle>
+                            <CardDescription>
+                                Layout dengan Card component dari shadcn/ui
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <Link href="/auth/demo/card">
+                                <Button className="w-full" variant="outline">
+                                    Lihat Card Layout
+                                </Button>
+                            </Link>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Split Layout</CardTitle>
+                            <CardDescription>
+                                Layout dengan panel samping untuk branding
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <Link href="/auth/demo/split">
+                                <Button className="w-full" variant="outline">
+                                    Lihat Split Layout
+                                </Button>
+                            </Link>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Live Auth Pages</CardTitle>
+                            <CardDescription>
+                                Halaman auth yang sudah diperbarui dengan style bersih
+                            </CardDescription>
+                        </CardHeader>
+                        <CardContent className="space-y-2">
+                            <Link href={route('login')} className="block">
+                                <Button className="w-full" variant="secondary">
+                                    Login Page
+                                </Button>
+                            </Link>
+                            <Link href={route('register')} className="block">
+                                <Button className="w-full" variant="secondary">
+                                    Register Page
+                                </Button>
+                            </Link>
+                            <Link href={route('password.request')} className="block">
+                                <Button className="w-full" variant="secondary">
+                                    Forgot Password
+                                </Button>
+                            </Link>
+                        </CardContent>
+                    </Card>
+                </div>
+
+                <div className="text-center text-sm text-muted-foreground">
+                    <p>Semua layout menggunakan komponen shadcn/ui standar</p>
+                    <p>Tidak ada warna custom atau gradient yang membuat tampilan berbeda</p>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/pages/auth/reset-password.tsx
+++ b/resources/js/pages/auth/reset-password.tsx
@@ -27,8 +27,8 @@ export default function ResetPassword({ token, email }: ResetPasswordProps) {
                     <div className="grid gap-6">
                         <div className="grid gap-2">
                             <Label htmlFor="email">Email</Label>
-                            <Input id="email" type="email" name="email" autoComplete="email" value={email} className="mt-1 block w-full" readOnly />
-                            <InputError message={errors.email} className="mt-2" />
+                            <Input id="email" type="email" name="email" autoComplete="email" value={email} readOnly />
+                            <InputError message={errors.email} />
                         </div>
 
                         <div className="grid gap-2">
@@ -38,7 +38,6 @@ export default function ResetPassword({ token, email }: ResetPasswordProps) {
                                 type="password"
                                 name="password"
                                 autoComplete="new-password"
-                                className="mt-1 block w-full"
                                 autoFocus
                                 placeholder="Password baru"
                             />
@@ -52,13 +51,12 @@ export default function ResetPassword({ token, email }: ResetPasswordProps) {
                                 type="password"
                                 name="password_confirmation"
                                 autoComplete="new-password"
-                                className="mt-1 block w-full"
                                 placeholder="Konfirmasi password baru"
                             />
-                            <InputError message={errors.password_confirmation} className="mt-2" />
+                            <InputError message={errors.password_confirmation} />
                         </div>
 
-                        <Button type="submit" className="mt-4 w-full" disabled={processing}>
+                        <Button type="submit" className="w-full" disabled={processing}>
                             {processing && <LoaderCircle className="h-4 w-4 animate-spin" />}
                             Reset Password
                         </Button>


### PR DESCRIPTION
Update authentication pages and layouts to use consistent shadcn/ui styling, removing custom colors and gradients.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7803ac0-8a12-4ffb-8370-d5d162b49fdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7803ac0-8a12-4ffb-8370-d5d162b49fdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

