### PR TITLE
Fix login and register error redirects

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -81,13 +81,24 @@ return Application::configure(basePath: dirname(__DIR__))
             }
         });
 
-        // Handle any other exception (but skip ValidationException)
+        // Handle any other exception (but skip ValidationException and other framework exceptions)
         $exceptions->render(function (\Throwable $e, $request) {
             // Don't handle ValidationException - let it be handled by Laravel's default validation handling
             if ($e instanceof ValidationException) {
                 return null; // Return null to let Laravel handle it normally
             }
-
+            
+            // Don't handle AuthenticationException - it has its own handler above
+            if ($e instanceof AuthenticationException) {
+                return null;
+            }
+            
+            // Don't handle HttpException - it has its own handler above
+            if ($e instanceof HttpException) {
+                return null;
+            }
+            
+            // Only handle actual server errors (500) for unexpected exceptions
             if ($request->wantsJson() || $request->inertia()) {
                 // In production, don't expose internal errors
                 $isDebug = config('app.debug');
@@ -100,12 +111,22 @@ return Application::configure(basePath: dirname(__DIR__))
         });
 
         $exceptions->respond(function ($response, $exception, $request) {
+            // Skip validation errors - they should be handled by Inertia automatically
+            if ($exception instanceof ValidationException) {
+                return $response;
+            }
+            
             // List of error codes we have custom pages for
             $customErrorPages = [403, 404, 419, 500, 503];
             $statusCode = $response->getStatusCode();
 
             // Handle Inertia requests
             if ($request->inertia()) {
+                // Don't interfere with 422 validation errors
+                if ($statusCode === 422) {
+                    return $response;
+                }
+                
                 // Handle 419 (CSRF token mismatch) specially
                 if ($statusCode === 419) {
                     return Inertia::render('errors/419', [

--- a/lang/id/validation.php
+++ b/lang/id/validation.php
@@ -1,0 +1,189 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => ':attribute harus diterima.',
+    'accepted_if' => ':attribute harus diterima ketika :other adalah :value.',
+    'active_url' => ':attribute bukan URL yang valid.',
+    'after' => ':attribute harus berupa tanggal setelah :date.',
+    'after_or_equal' => ':attribute harus berupa tanggal setelah atau sama dengan :date.',
+    'alpha' => ':attribute hanya boleh berisi huruf.',
+    'alpha_dash' => ':attribute hanya boleh berisi huruf, angka, tanda hubung, dan garis bawah.',
+    'alpha_num' => ':attribute hanya boleh berisi huruf dan angka.',
+    'array' => ':attribute harus berupa array.',
+    'before' => ':attribute harus berupa tanggal sebelum :date.',
+    'before_or_equal' => ':attribute harus berupa tanggal sebelum atau sama dengan :date.',
+    'between' => [
+        'array' => ':attribute harus memiliki antara :min dan :max item.',
+        'file' => ':attribute harus berukuran antara :min dan :max kilobyte.',
+        'numeric' => ':attribute harus bernilai antara :min dan :max.',
+        'string' => ':attribute harus berisi antara :min dan :max karakter.',
+    ],
+    'boolean' => ':attribute harus bernilai true atau false.',
+    'confirmed' => 'Konfirmasi :attribute tidak cocok.',
+    'current_password' => 'Password salah.',
+    'date' => ':attribute bukan tanggal yang valid.',
+    'date_equals' => ':attribute harus berupa tanggal yang sama dengan :date.',
+    'date_format' => ':attribute tidak sesuai dengan format :format.',
+    'declined' => ':attribute harus ditolak.',
+    'declined_if' => ':attribute harus ditolak ketika :other adalah :value.',
+    'different' => ':attribute dan :other harus berbeda.',
+    'digits' => ':attribute harus berisi :digits digit.',
+    'digits_between' => ':attribute harus berisi antara :min dan :max digit.',
+    'dimensions' => ':attribute memiliki dimensi gambar yang tidak valid.',
+    'distinct' => ':attribute memiliki nilai duplikat.',
+    'doesnt_end_with' => ':attribute tidak boleh diakhiri dengan salah satu dari: :values.',
+    'doesnt_start_with' => ':attribute tidak boleh diawali dengan salah satu dari: :values.',
+    'email' => ':attribute harus berupa alamat email yang valid.',
+    'ends_with' => ':attribute harus diakhiri dengan salah satu dari: :values.',
+    'enum' => ':attribute yang dipilih tidak valid.',
+    'exists' => ':attribute yang dipilih tidak valid.',
+    'file' => ':attribute harus berupa file.',
+    'filled' => ':attribute harus memiliki nilai.',
+    'gt' => [
+        'array' => ':attribute harus memiliki lebih dari :value item.',
+        'file' => ':attribute harus lebih besar dari :value kilobyte.',
+        'numeric' => ':attribute harus lebih besar dari :value.',
+        'string' => ':attribute harus lebih dari :value karakter.',
+    ],
+    'gte' => [
+        'array' => ':attribute harus memiliki :value item atau lebih.',
+        'file' => ':attribute harus lebih besar atau sama dengan :value kilobyte.',
+        'numeric' => ':attribute harus lebih besar atau sama dengan :value.',
+        'string' => ':attribute harus berisi :value karakter atau lebih.',
+    ],
+    'image' => ':attribute harus berupa gambar.',
+    'in' => ':attribute yang dipilih tidak valid.',
+    'in_array' => ':attribute tidak ada dalam :other.',
+    'integer' => ':attribute harus berupa bilangan bulat.',
+    'ip' => ':attribute harus berupa alamat IP yang valid.',
+    'ipv4' => ':attribute harus berupa alamat IPv4 yang valid.',
+    'ipv6' => ':attribute harus berupa alamat IPv6 yang valid.',
+    'json' => ':attribute harus berupa string JSON yang valid.',
+    'lowercase' => ':attribute harus berupa huruf kecil.',
+    'lt' => [
+        'array' => ':attribute harus memiliki kurang dari :value item.',
+        'file' => ':attribute harus lebih kecil dari :value kilobyte.',
+        'numeric' => ':attribute harus lebih kecil dari :value.',
+        'string' => ':attribute harus kurang dari :value karakter.',
+    ],
+    'lte' => [
+        'array' => ':attribute tidak boleh memiliki lebih dari :value item.',
+        'file' => ':attribute harus lebih kecil atau sama dengan :value kilobyte.',
+        'numeric' => ':attribute harus lebih kecil atau sama dengan :value.',
+        'string' => ':attribute harus berisi :value karakter atau kurang.',
+    ],
+    'mac_address' => ':attribute harus berupa alamat MAC yang valid.',
+    'max' => [
+        'array' => ':attribute tidak boleh memiliki lebih dari :max item.',
+        'file' => ':attribute tidak boleh lebih besar dari :max kilobyte.',
+        'numeric' => ':attribute tidak boleh lebih besar dari :max.',
+        'string' => ':attribute tidak boleh lebih dari :max karakter.',
+    ],
+    'max_digits' => ':attribute tidak boleh memiliki lebih dari :max digit.',
+    'mimes' => ':attribute harus berupa file dengan tipe: :values.',
+    'mimetypes' => ':attribute harus berupa file dengan tipe: :values.',
+    'min' => [
+        'array' => ':attribute harus memiliki minimal :min item.',
+        'file' => ':attribute harus berukuran minimal :min kilobyte.',
+        'numeric' => ':attribute harus bernilai minimal :min.',
+        'string' => ':attribute harus berisi minimal :min karakter.',
+    ],
+    'min_digits' => ':attribute harus memiliki minimal :min digit.',
+    'missing' => ':attribute harus tidak ada.',
+    'missing_if' => ':attribute harus tidak ada ketika :other adalah :value.',
+    'missing_unless' => ':attribute harus tidak ada kecuali :other adalah :value.',
+    'missing_with' => ':attribute harus tidak ada ketika :values ada.',
+    'missing_with_all' => ':attribute harus tidak ada ketika :values ada.',
+    'multiple_of' => ':attribute harus merupakan kelipatan dari :value.',
+    'not_in' => ':attribute yang dipilih tidak valid.',
+    'not_regex' => 'Format :attribute tidak valid.',
+    'numeric' => ':attribute harus berupa angka.',
+    'password' => [
+        'letters' => ':attribute harus mengandung minimal satu huruf.',
+        'mixed' => ':attribute harus mengandung minimal satu huruf besar dan satu huruf kecil.',
+        'numbers' => ':attribute harus mengandung minimal satu angka.',
+        'symbols' => ':attribute harus mengandung minimal satu simbol.',
+        'uncompromised' => ':attribute yang diberikan telah muncul dalam kebocoran data. Silakan pilih :attribute yang berbeda.',
+    ],
+    'present' => ':attribute harus ada.',
+    'prohibited' => ':attribute dilarang.',
+    'prohibited_if' => ':attribute dilarang ketika :other adalah :value.',
+    'prohibited_unless' => ':attribute dilarang kecuali :other ada dalam :values.',
+    'prohibits' => ':attribute melarang :other untuk ada.',
+    'regex' => 'Format :attribute tidak valid.',
+    'required' => ':attribute wajib diisi.',
+    'required_array_keys' => ':attribute harus berisi entri untuk: :values.',
+    'required_if' => ':attribute wajib diisi ketika :other adalah :value.',
+    'required_if_accepted' => ':attribute wajib diisi ketika :other diterima.',
+    'required_unless' => ':attribute wajib diisi kecuali :other ada dalam :values.',
+    'required_with' => ':attribute wajib diisi ketika :values ada.',
+    'required_with_all' => ':attribute wajib diisi ketika :values ada.',
+    'required_without' => ':attribute wajib diisi ketika :values tidak ada.',
+    'required_without_all' => ':attribute wajib diisi ketika tidak ada :values yang ada.',
+    'same' => ':attribute dan :other harus sama.',
+    'size' => [
+        'array' => ':attribute harus berisi :size item.',
+        'file' => ':attribute harus berukuran :size kilobyte.',
+        'numeric' => ':attribute harus bernilai :size.',
+        'string' => ':attribute harus berisi :size karakter.',
+    ],
+    'starts_with' => ':attribute harus diawali dengan salah satu dari: :values.',
+    'string' => ':attribute harus berupa string.',
+    'timezone' => ':attribute harus berupa zona waktu yang valid.',
+    'unique' => ':attribute sudah digunakan.',
+    'uploaded' => ':attribute gagal diunggah.',
+    'uppercase' => ':attribute harus berupa huruf besar.',
+    'url' => ':attribute harus berupa URL yang valid.',
+    'ulid' => ':attribute harus berupa ULID yang valid.',
+    'uuid' => ':attribute harus berupa UUID yang valid.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'email' => [
+            'unique' => 'Email ini sudah terdaftar. Silakan gunakan email lain atau login dengan email tersebut.',
+        ],
+        'password' => [
+            'confirmed' => 'Konfirmasi password tidak cocok.',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [
+        'email' => 'Email',
+        'password' => 'Password',
+        'password_confirmation' => 'Konfirmasi Password',
+        'name' => 'Nama',
+        'remember' => 'Ingat Saya',
+    ],
+];

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -1,14 +1,19 @@
 import { Form, Head } from '@inertiajs/react';
 import { LoaderCircle } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 import InputError from '@/components/input-error';
 import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { useToast } from '@/hooks/use-toast';
 import AuthLayout from '@/layouts/auth-layout';
 
 export default function Register() {
+    const { toast } = useToast();
+    const [hasShownToast, setHasShownToast] = useState(false);
+    
     return (
         <AuthLayout title="Buat Akun Baru" description="Masukkan detail Anda untuk membuat akun di platform Pare EduHub">
             <Head title="Daftar" />
@@ -19,7 +24,40 @@ export default function Register() {
                 disableWhileProcessing
                 className="flex flex-col gap-6"
             >
-                {({ processing, errors }) => (
+                {({ processing, errors }) => {
+                    // Show toast for validation errors
+                    useEffect(() => {
+                        if (errors.email && (errors.email.includes('sudah digunakan') || errors.email.includes('sudah terdaftar') || errors.email.includes('already been taken')) && !hasShownToast) {
+                            toast({
+                                variant: 'destructive',
+                                title: 'Registrasi Gagal',
+                                description: 'Email sudah terdaftar. Silakan gunakan email lain atau login dengan email tersebut.',
+                            });
+                            setHasShownToast(true);
+                        } else if (errors.password && (errors.password.includes('konfirmasi') || errors.password.includes('confirmation')) && !hasShownToast) {
+                            toast({
+                                variant: 'destructive',
+                                title: 'Registrasi Gagal',
+                                description: 'Konfirmasi password tidak cocok. Pastikan password dan konfirmasi password sama.',
+                            });
+                            setHasShownToast(true);
+                        } else if (Object.keys(errors).length > 0 && !hasShownToast) {
+                            const firstError = Object.values(errors)[0];
+                            toast({
+                                variant: 'destructive',
+                                title: 'Registrasi Gagal',
+                                description: firstError || 'Silakan periksa kembali data yang Anda masukkan.',
+                            });
+                            setHasShownToast(true);
+                        }
+
+                        // Reset the flag when errors are cleared
+                        if (Object.keys(errors).length === 0) {
+                            setHasShownToast(false);
+                        }
+                    }, [errors]);
+                    
+                    return (
                     <>
                         <div className="grid gap-6">
                             <div className="grid gap-2">
@@ -92,7 +130,8 @@ export default function Register() {
                             </TextLink>
                         </div>
                     </>
-                )}
+                    );
+                }}
             </Form>
         </AuthLayout>
     );


### PR DESCRIPTION
Fix authentication error handling to display toast notifications and input errors instead of redirecting to a 500 page.

Previously, the generic exception handler in `bootstrap/app.php` was catching `ValidationException` and other specific exceptions for Inertia requests, causing redirects to a 500 error page. This change ensures these exceptions are handled gracefully by Laravel's default mechanisms, providing user-friendly feedback (toasts, input errors) and localized messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-404a103e-6679-4e88-a11e-09c0deaed9bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-404a103e-6679-4e88-a11e-09c0deaed9bd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

