### PR TITLE
Investigate duplicate login error toast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "online-course",
+    "name": "workspace",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -20,17 +20,19 @@ function LoginFormContent({
     processing,
     errors,
     canResetPassword,
+    submitCount,
 }: {
     processing: boolean;
     errors: { email?: string; password?: string; [key: string]: string | undefined };
     canResetPassword: boolean;
+    submitCount: number;
 }) {
     const { toast } = useToast();
-    const [hasShownToast, setHasShownToast] = useState(false);
+    const [lastSubmitCount, setLastSubmitCount] = useState(0);
 
     useEffect(() => {
-        // Handle different error scenarios
-        if (Object.keys(errors).length > 0 && !hasShownToast) {
+        // Show toast when there are errors and this is a new submission
+        if (Object.keys(errors).length > 0 && submitCount > lastSubmitCount) {
             let toastTitle = 'Login Gagal';
             let toastDescription = 'Terjadi kesalahan saat login.';
             
@@ -60,14 +62,11 @@ function LoginFormContent({
                 title: toastTitle,
                 description: toastDescription,
             });
-            setHasShownToast(true);
+            
+            // Update last submit count
+            setLastSubmitCount(submitCount);
         }
-
-        // Reset the flag when errors are cleared
-        if (Object.keys(errors).length === 0) {
-            setHasShownToast(false);
-        }
-    }, [errors, toast, hasShownToast]);
+    }, [errors, submitCount, toast, lastSubmitCount]);
 
     return (
         <div className="space-y-6">
@@ -158,12 +157,24 @@ function LoginFormContent({
 }
 
 export default function Login({ status, canResetPassword }: LoginProps) {
+    const [submitCount, setSubmitCount] = useState(0);
+    
     return (
         <AuthLayout title="Masuk ke Akun Anda" description="Masukkan email dan password Anda untuk masuk ke platform Pare EduHub">
             <Head title="Masuk" />
 
-            <Form method="post" action={route('login')} resetOnSuccess={['password']} className="space-y-6">
-                {({ processing, errors }) => <LoginFormContent processing={processing} errors={errors} canResetPassword={canResetPassword} />}
+            <Form 
+                method="post" 
+                action={route('login')} 
+                resetOnSuccess={['password']} 
+                className="space-y-6"
+                onBefore={() => {
+                    // Increment submit count when form is submitted
+                    setSubmitCount(prev => prev + 1);
+                    return true;
+                }}
+            >
+                {({ processing, errors }) => <LoginFormContent processing={processing} errors={errors} canResetPassword={canResetPassword} submitCount={submitCount} />}
             </Form>
 
             {status && (


### PR DESCRIPTION
Show login error toast on every failed submission attempt to provide consistent user feedback.

The previous implementation used a `hasShownToast` flag which prevented the toast from reappearing if the same error persisted across multiple failed login attempts. This PR introduces a `submitCount` mechanism to track each form submission, ensuring the error toast is displayed for every new attempt, regardless of whether the error message has changed.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ba3df38-45ff-4c2e-ab8a-77b4b458decd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ba3df38-45ff-4c2e-ab8a-77b4b458decd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

