### PR TITLE
Ganti alert unauthenticated dengan popup shadcn ui

### DIFF
--- a/resources/js/pages/courses/index.tsx
+++ b/resources/js/pages/courses/index.tsx
@@ -21,6 +21,14 @@ import {
 import { Link, router, usePage } from '@inertiajs/react';
 import { useState } from 'react';
 import { useAuth } from '@/hooks/use-auth';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 
 interface Course {
     id: number;
@@ -78,6 +86,7 @@ export default function CoursesIndex() {
     const { isAuthenticated } = useAuth();
     const [searchTerm, setSearchTerm] = useState(filters.search || '');
     const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
+    const [showLoginDialog, setShowLoginDialog] = useState(false);
 
     const handleSearch = (e: React.FormEvent) => {
         e.preventDefault();
@@ -94,12 +103,15 @@ export default function CoursesIndex() {
 
     const handleBookCourse = (courseId: number, isPro: boolean) => {
         if (!isAuthenticated) {
-            alert('Silakan login atau daftar terlebih dahulu untuk memesan kursus ini.');
-            router.visit('/login');
+            setShowLoginDialog(true);
         } else {
             // Navigate to enrollment/payment page
             router.visit(`/courses/${courseId}/enroll`);
         }
+    };
+
+    const handleLoginRedirect = () => {
+        router.visit('/login');
     };
 
     const CourseCard = ({ course }: { course: Course }) => (
@@ -424,6 +436,23 @@ export default function CoursesIndex() {
                     )}
                 </div>
             </section>
+
+            {/* Login Required Dialog */}
+            <Dialog open={showLoginDialog} onOpenChange={setShowLoginDialog}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Login Diperlukan</DialogTitle>
+                        <DialogDescription>
+                            Silakan login atau daftar terlebih dahulu untuk memesan kursus ini.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button onClick={handleLoginRedirect}>
+                            OK
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </GuestLayout>
     );
 }

--- a/resources/js/pages/courses/show.tsx
+++ b/resources/js/pages/courses/show.tsx
@@ -26,6 +26,15 @@ import {
 } from 'lucide-react';
 import { Link, router, usePage } from '@inertiajs/react';
 import { useAuth } from '@/hooks/use-auth';
+import { useState } from 'react';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
 
 interface CourseMaterial {
     id: number;
@@ -103,15 +112,19 @@ interface PageProps {
 export default function CourseShow() {
     const { course, isEnrolled, relatedCourses } = usePage<PageProps>().props;
     const { isAuthenticated } = useAuth();
+    const [showLoginDialog, setShowLoginDialog] = useState(false);
 
     const handleEnroll = () => {
         if (!isAuthenticated) {
-            alert('Silakan login atau daftar terlebih dahulu untuk mendaftar kursus ini.');
-            router.visit('/login');
+            setShowLoginDialog(true);
         } else {
             // Navigate to enrollment/payment page
             router.visit(`/courses/${course.id}/enroll`);
         }
+    };
+
+    const handleLoginRedirect = () => {
+        router.visit('/login');
     };
 
     const getMaterialIcon = (type: string) => {
@@ -522,6 +535,23 @@ export default function CourseShow() {
                     </div>
                 </div>
             </section>
+
+            {/* Login Required Dialog */}
+            <Dialog open={showLoginDialog} onOpenChange={setShowLoginDialog}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Login Diperlukan</DialogTitle>
+                        <DialogDescription>
+                            Silakan login atau daftar terlebih dahulu untuk memesan kursus ini.
+                        </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button onClick={handleLoginRedirect}>
+                            OK
+                        </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
         </GuestLayout>
     );
 }


### PR DESCRIPTION
Replace browser `alert()` with a Shadcn UI dialog for login-required actions to improve UI/UX and redirect to the login page.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a1c5499-db49-492c-a52b-2836e2b442e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a1c5499-db49-492c-a52b-2836e2b442e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

