### PR TITLE
Perbaiki error 500 saat akses dashboard

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -12,24 +12,33 @@ class UserController extends Controller
         $user = auth()->user();
         
         // Get user's enrolled courses with progress
-        $enrollments = \App\Models\Enrollment::with(['course' => function($query) {
+        $enrollmentsQuery = \App\Models\Enrollment::with(['course' => function($query) {
             $query->with(['category', 'institution', 'chapters'])
                 ->where('status', 'published')
                 ->withAvg('reviews', 'rating')
                 ->withCount(['enrollments', 'chapters']);
         }])
-        ->where('user_id', $user->id)
-        ->orderBy('enrolled_at', 'desc')
-        ->get()
-        ->map(function ($enrollment) {
+        ->where('user_id', $user->id);
+        
+        // Check if enrolled_at column exists and order accordingly
+        try {
+            $enrollments = $enrollmentsQuery->orderBy('enrolled_at', 'desc')->get();
+        } catch (\Exception $e) {
+            // If enrolled_at doesn't exist, use created_at
+            $enrollments = $enrollmentsQuery->orderBy('created_at', 'desc')->get();
+        }
+        
+        $enrollments = $enrollments->map(function ($enrollment) {
             $course = $enrollment->course;
             if ($course) {
                 $course->average_rating = $course->reviews_avg_rating ?? 0;
                 $course->total_students = $course->enrollments_count;
                 $course->total_chapters = $course->chapters_count;
-                $course->user_progress = $enrollment->progress;
-                $course->enrolled_at = $enrollment->enrolled_at;
-                $course->completed_at = $enrollment->completed_at;
+                
+                // Safely access columns that might not exist
+                $course->user_progress = $enrollment->progress ?? 0;
+                $course->enrolled_at = $enrollment->enrolled_at ?? $enrollment->created_at;
+                $course->completed_at = $enrollment->completed_at ?? null;
             }
             return $course;
         })
@@ -53,24 +62,33 @@ class UserController extends Controller
         $user = auth()->user();
         
         // Get user's enrolled courses with progress
-        $enrollments = \App\Models\Enrollment::with(['course' => function($query) {
+        $enrollmentsQuery = \App\Models\Enrollment::with(['course' => function($query) {
             $query->with(['category', 'institution', 'chapters'])
                 ->where('status', 'published')
                 ->withAvg('reviews', 'rating')
                 ->withCount(['enrollments', 'chapters']);
         }])
-        ->where('user_id', $user->id)
-        ->orderBy('enrolled_at', 'desc')
-        ->get()
-        ->map(function ($enrollment) {
+        ->where('user_id', $user->id);
+        
+        // Check if enrolled_at column exists and order accordingly
+        try {
+            $enrollments = $enrollmentsQuery->orderBy('enrolled_at', 'desc')->get();
+        } catch (\Exception $e) {
+            // If enrolled_at doesn't exist, use created_at
+            $enrollments = $enrollmentsQuery->orderBy('created_at', 'desc')->get();
+        }
+        
+        $enrollments = $enrollments->map(function ($enrollment) {
             $course = $enrollment->course;
             if ($course) {
                 $course->average_rating = $course->reviews_avg_rating ?? 0;
                 $course->total_students = $course->enrollments_count;
                 $course->total_chapters = $course->chapters_count;
-                $course->user_progress = $enrollment->progress;
-                $course->enrolled_at = $enrollment->enrolled_at;
-                $course->completed_at = $enrollment->completed_at;
+                
+                // Safely access columns that might not exist
+                $course->user_progress = $enrollment->progress ?? 0;
+                $course->enrolled_at = $enrollment->enrolled_at ?? $enrollment->created_at;
+                $course->completed_at = $enrollment->completed_at ?? null;
             }
             return $course;
         })

--- a/database/migrations/2025_01_01_000000_add_progress_fields_to_enrollments_table.php
+++ b/database/migrations/2025_01_01_000000_add_progress_fields_to_enrollments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('enrollments', function (Blueprint $table) {
+            $table->timestamp('enrolled_at')->nullable()->after('course_id');
+            $table->timestamp('completed_at')->nullable()->after('enrolled_at');
+            $table->integer('progress')->default(0)->after('completed_at');
+        });
+
+        // Update existing records to have enrolled_at set to created_at
+        DB::table('enrollments')->whereNull('enrolled_at')->update(['enrolled_at' => DB::raw('created_at')]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('enrollments', function (Blueprint $table) {
+            $table->dropColumn(['enrolled_at', 'completed_at', 'progress']);
+        });
+    }
+};


### PR DESCRIPTION
Add missing enrollment progress fields and make UserController robust against their absence to fix 500 error on user dashboard.

The `enrollments` table was missing `enrolled_at`, `completed_at`, and `progress` columns, causing SQL errors when `UserController` attempted to order by `enrolled_at` or access these attributes. This PR introduces a migration to add these columns and updates the controller to gracefully handle their absence, preventing 500 errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-5381a9fc-68f5-4801-8a1b-5c63ffdeef8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5381a9fc-68f5-4801-8a1b-5c63ffdeef8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

