### PR TITLE
Fix free course registration data saving

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -186,6 +186,25 @@ class CourseController extends Controller
             abort(404);
         }
 
+        // If course is free, bypass payment/enroll page and enroll directly
+        if (!$course->is_pro && (int) $course->price === 0) {
+            if (!auth()->check()) {
+                return redirect()->route('login')
+                    ->with('info', 'Silakan login untuk mendaftar di kursus ini.');
+            }
+
+            // If already enrolled, send to learn page
+            $alreadyEnrolled = $course->enrollments()
+                ->where('user_id', auth()->id())
+                ->exists();
+            if ($alreadyEnrolled) {
+                return redirect()->route('courses.learn', $course->id)
+                    ->with('info', 'Anda sudah terdaftar di kursus ini.');
+            }
+
+            return $this->enrollFree($course->id);
+        }
+
         // Check if user is already enrolled
         $isEnrolled = false;
         if (auth()->check()) {
@@ -240,7 +259,7 @@ class CourseController extends Controller
 
         if ($isEnrolled) {
             \Log::info('User already enrolled', ['course_id' => $id, 'user_id' => auth()->id()]);
-            return redirect()->route('courses.learn', $course->id)
+            return redirect()->route('user.my-courses')
                 ->with('info', 'Anda sudah terdaftar di kursus ini.');
         }
 
@@ -261,7 +280,7 @@ class CourseController extends Controller
                 ]);
             });
 
-            return redirect()->route('courses.learn', $course->id)
+            return redirect()->route('user.my-courses')
                 ->with('success', 'Selamat! Anda berhasil mendaftar di kursus ini.');
         } catch (\Exception $e) {
             \Log::error('Failed to enroll user in free course', [

--- a/app/Models/Chapter.php
+++ b/app/Models/Chapter.php
@@ -42,6 +42,14 @@ class Chapter extends Model
     }
 
     /**
+     * Alias relation for courseMaterials to match frontend expectation.
+     */
+    public function materials(): HasMany
+    {
+        return $this->hasMany(CourseMaterial::class);
+    }
+
+    /**
      * Progress records for this chapter.
      */
     public function progress(): HasMany

--- a/resources/js/pages/courses/enroll.tsx
+++ b/resources/js/pages/courses/enroll.tsx
@@ -53,16 +53,24 @@ export default function EnrollCourse({ course }: PageProps) {
     });
 
     const handleEnrollment = async () => {
-        if (!course.is_pro) {
+        if (!course.is_pro && course.price === 0) {
             setIsProcessing(true);
-            setAlertState({
-                open: true,
-                title: 'Pendaftaran Berhasil',
-                description: 'Selamat! Anda telah berhasil mendaftar di kursus gratis ini.',
-                type: 'success',
-                onAction: () => router.visit(`/courses/${course.id}`)
+            router.post(`/courses/${course.id}/enroll-free`, {}, {
+                onSuccess: () => {
+                    router.visit('/user/my-courses');
+                },
+                onError: () => {
+                    setAlertState({
+                        open: true,
+                        title: 'Pendaftaran Gagal',
+                        description: 'Terjadi kesalahan saat mendaftar kursus gratis.',
+                        type: 'error',
+                    });
+                },
+                onFinish: () => {
+                    setIsProcessing(false);
+                },
             });
-            setIsProcessing(false);
             return;
         }
 

--- a/resources/js/pages/courses/show.tsx
+++ b/resources/js/pages/courses/show.tsx
@@ -281,7 +281,7 @@ export default function CourseShow() {
 
                                     {isEnrolled ? (
                                         <Button size="lg" className="w-full" asChild>
-                                            <Link href={`/user/courses/${course.id}`}>
+                                            <Link href={`/courses/${course.id}/learn`}>
                                                 Lanjutkan Belajar
                                             </Link>
                                         </Button>


### PR DESCRIPTION
Implement direct enrollment for free courses, bypassing the payment gateway, because previous registrations were not saved to the database.

Previously, the frontend for free courses on the enrollment page (`enroll.tsx`) only displayed a success message without making a backend call, preventing the creation of `enrollment` records. This PR ensures free courses directly trigger the backend `enroll-free` endpoint, introduces a backend guard to streamline the process, and corrects related redirects and a missing model relation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2332e0c0-6294-46bd-92be-a392b2571845">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2332e0c0-6294-46bd-92be-a392b2571845">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

