### PR TITLE
Investigate user learn page 500 error

### DIFF
--- a/app/Http/Controllers/CourseController.php
+++ b/app/Http/Controllers/CourseController.php
@@ -319,10 +319,14 @@ class CourseController extends Controller
         $course->enrolled_at = $enrollment->enrolled_at;
         $course->completed_at = $enrollment->completed_at;
 
-        // Get completed materials for this user
-        $completedMaterials = \App\Models\UserMaterialProgress::where('user_id', auth()->id())
-            ->whereIn('material_id', $course->chapters->flatMap->materials->pluck('id'))
-            ->pluck('material_id')
+        // Get completed materials for this user based on completed chapters
+        $completedChapterIds = \App\Models\ChapterProgress::where('user_id', auth()->id())
+            ->where('enrollment_id', $enrollment->id)
+            ->where('is_completed', true)
+            ->pluck('chapter_id');
+
+        $completedMaterials = \App\Models\CourseMaterial::whereIn('chapter_id', $completedChapterIds)
+            ->pluck('id')
             ->toArray();
 
         return Inertia::render('courses/learn', [


### PR DESCRIPTION
Fixes 500 error on the learn page by replacing a non-existent `UserMaterialProgress` model with `ChapterProgress` and `CourseMaterial` to derive completed materials.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c87d8bc-98b9-4032-b05b-02411a2a7289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6c87d8bc-98b9-4032-b05b-02411a2a7289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

