### PR TITLE
Perbaiki tampilan video materi pembelajaran

### DIFF
--- a/app/Models/CourseMaterial.php
+++ b/app/Models/CourseMaterial.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Facades\Storage;
 
 class CourseMaterial extends Model
 {
@@ -23,6 +24,19 @@ class CourseMaterial extends Model
     protected $casts = [
         'is_preview' => 'boolean',
     ];
+
+    protected $appends = ['file_url'];
+
+    /**
+     * Get the full URL for the file_path
+     */
+    public function getFileUrlAttribute()
+    {
+        if ($this->file_path) {
+            return Storage::disk('public')->url($this->file_path);
+        }
+        return null;
+    }
 
     /**
      * Bab yang memiliki materi ini.

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -5,6 +5,12 @@
 
     RewriteEngine On
 
+    # PHP Upload Limits for Video Support
+    php_value upload_max_filesize 100M
+    php_value post_max_size 105M
+    php_value max_execution_time 300
+    php_value max_input_time 300
+
     # Handle Authorization Header
     RewriteCond %{HTTP:Authorization} .
     RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]

--- a/resources/js/pages/admin/materials/show.tsx
+++ b/resources/js/pages/admin/materials/show.tsx
@@ -10,10 +10,11 @@ interface MaterialShowProps extends PageProps {
 	material: {
 		id: number;
 		title: string;
-		type: 'pdf'|'image'|'video';
+		type: 'pdf'|'image'|'video_local'|'video_youtube';
 		order: number;
 		is_preview: boolean;
 		file_path: string | null;
+		file_url?: string | null;
 		youtube_url: string | null;
 		chapter: { id: number; title: string; course: { id: number; title: string } };
 		created_at: string;
@@ -62,15 +63,20 @@ export default function MaterialShow({ material }: MaterialShowProps) {
 						</div>
 
 						<div className="p-4 border rounded-md">
-							{material.type === 'video' ? (
+							{material.type === 'video_youtube' ? (
 								<div className="flex items-center gap-2 text-sm">
 									<Video className="h-4 w-4" />
-									<span>{material.youtube_url || '-'}</span>
+									<span>YouTube: {material.youtube_url || '-'}</span>
+								</div>
+							) : material.type === 'video_local' ? (
+								<div className="flex items-center gap-2 text-sm">
+									<Video className="h-4 w-4" />
+									<span>Video: {material.file_url || material.file_path || '-'}</span>
 								</div>
 							) : (
 								<div className="flex items-center gap-2 text-sm">
 									<File className="h-4 w-4" />
-									<span>{material.file_path || '-'}</span>
+									<span>File: {material.file_url || material.file_path || '-'}</span>
 								</div>
 							)}
 						</div>

--- a/resources/js/pages/courses/learn.tsx
+++ b/resources/js/pages/courses/learn.tsx
@@ -34,6 +34,7 @@ interface Material {
     title: string;
     type: 'pdf' | 'image' | 'video_local' | 'video_youtube';
     file_path?: string | null;
+    file_url?: string | null;
     youtube_url?: string | null;
     order: number;
 }
@@ -312,11 +313,24 @@ export default function Learn({ course, completedMaterials, enrollment }: LearnP
                                                 </div>
                                             ) : selectedMaterial.type === 'video_local' ? (
                                                 <div className="aspect-video bg-black rounded-lg overflow-hidden flex items-center justify-center">
-                                                    {selectedMaterial.file_path ? (
-                                                        <video className="w-full h-full" src={selectedMaterial.file_path} controls />
+                                                    {(selectedMaterial.file_url || selectedMaterial.file_path) ? (
+                                                        <video 
+                                                            className="w-full h-full" 
+                                                            src={selectedMaterial.file_url || selectedMaterial.file_path} 
+                                                            controls 
+                                                            controlsList="nodownload"
+                                                            preload="metadata"
+                                                        >
+                                                            <source src={selectedMaterial.file_url || selectedMaterial.file_path} type="video/mp4" />
+                                                            <source src={selectedMaterial.file_url || selectedMaterial.file_path} type="video/webm" />
+                                                            <source src={selectedMaterial.file_url || selectedMaterial.file_path} type="video/ogg" />
+                                                            <source src={selectedMaterial.file_url || selectedMaterial.file_path} type="video/quicktime" />
+                                                            Browser Anda tidak mendukung tag video.
+                                                        </video>
                                                     ) : (
                                                         <div className="w-full h-full flex items-center justify-center">
                                                             <Video className="h-12 w-12 text-muted-foreground" />
+                                                            <p className="text-muted-foreground mt-2">Video tidak tersedia</p>
                                                         </div>
                                                     )}
                                                 </div>
@@ -326,14 +340,14 @@ export default function Learn({ course, completedMaterials, enrollment }: LearnP
                                                         <FileText className="h-5 w-5" />
                                                         <span>Dokumen PDF</span>
                                                     </div>
-                                                    {selectedMaterial.file_path ? (
-                                                        <iframe className="w-full h-[70vh] rounded" src={selectedMaterial.file_path} />
+                                                    {(selectedMaterial.file_url || selectedMaterial.file_path) ? (
+                                                        <iframe className="w-full h-[70vh] rounded" src={selectedMaterial.file_url || selectedMaterial.file_path} />
                                                     ) : (
                                                         <p className="text-muted-foreground">Dokumen tidak tersedia.</p>
                                                     )}
-                                                    {selectedMaterial.file_path && (
+                                                    {(selectedMaterial.file_url || selectedMaterial.file_path) && (
                                                         <Button className="mt-4" variant="outline" asChild>
-                                                            <a href={selectedMaterial.file_path} target="_blank" rel="noopener noreferrer">
+                                                            <a href={selectedMaterial.file_url || selectedMaterial.file_path} target="_blank" rel="noopener noreferrer">
                                                                 <Download className="mr-2 h-4 w-4" />
                                                                 Download PDF
                                                             </a>
@@ -342,8 +356,13 @@ export default function Learn({ course, completedMaterials, enrollment }: LearnP
                                                 </div>
                                             ) : (
                                                 <div className="min-h-[300px] bg-muted rounded-lg p-4 flex items-center justify-center">
-                                                    {selectedMaterial.file_path ? (
-                                                        <img src={selectedMaterial.file_path} alt={selectedMaterial.title} className="max-h-[70vh] rounded" />
+                                                    {(selectedMaterial.file_url || selectedMaterial.file_path) ? (
+                                                        <img 
+                                                            src={selectedMaterial.file_url || selectedMaterial.file_path} 
+                                                            alt={selectedMaterial.title} 
+                                                            className="max-h-[70vh] rounded" 
+                                                            loading="lazy"
+                                                        />
                                                     ) : (
                                                         <div className="text-center text-muted-foreground">
                                                             <ImageIcon className="mx-auto h-12 w-12 mb-2" />

--- a/test-video-display.md
+++ b/test-video-display.md
@@ -1,0 +1,90 @@
+# Video Display Test Guide
+
+## Summary of Changes
+
+I've successfully fixed the video display functionality on the learn page. Here are the changes made:
+
+### 1. **Backend Changes**
+
+#### CourseMaterial Model (`app/Models/CourseMaterial.php`)
+- Added `file_url` accessor that automatically converts the stored `file_path` to a full URL using Laravel's Storage facade
+- Added `file_url` to the model's `$appends` array so it's automatically included in JSON responses
+
+### 2. **Frontend Changes**
+
+#### Learn Page (`resources/js/pages/courses/learn.tsx`)
+- Updated the Material interface to include `file_url` property
+- Modified video player to use `file_url` (with fallback to `file_path`)
+- Added multiple source tags for better browser compatibility (mp4, webm, ogg, quicktime)
+- Added video controls and preload metadata
+- Improved error handling with user-friendly messages
+
+#### Admin Material Show Page (`resources/js/pages/admin/materials/show.tsx`)
+- Updated to support the new video types (`video_local` and `video_youtube`)
+- Added proper display of file URLs
+
+### 3. **Infrastructure Changes**
+
+#### Storage Symlink
+- Created storage symlink from `public/storage` to `storage/app/public` to serve uploaded files
+
+#### PHP Upload Limits (`.htaccess`)
+- Increased `upload_max_filesize` to 100M
+- Increased `post_max_size` to 105M
+- Increased execution time limits for large file uploads
+
+### 4. **Supported Video Formats**
+
+The system now supports the following video formats:
+- **MP4** (.mp4) - Most common format, widely supported
+- **MOV** (.mov) - QuickTime format
+- **AVI** (.avi) - Audio Video Interleave
+- **MKV** (.mkv) - Matroska format
+- **WMV** (.wmv) - Windows Media Video
+- **FLV** (.flv) - Flash Video
+- **WebM** (.webm) - Web-optimized format
+
+### 5. **Four Material Types Available**
+
+The system supports 4 types of materials that can be uploaded:
+1. **PDF Documents** - For text-based learning materials
+2. **Images** - Supporting JPG, PNG, GIF, WebP formats
+3. **Local Videos** - Videos stored on the server (MP4, MOV, AVI, MKV, WMV, FLV, WebM)
+4. **YouTube Videos** - Embedded YouTube videos using URL
+
+## Testing Instructions
+
+### To Test Video Upload and Display:
+
+1. **Upload a Video:**
+   - Go to Admin Panel → Materials → Create
+   - Select a course and chapter
+   - Choose "Video Lokal" as the type
+   - Upload a video file (MP4, MOV, etc., max 100MB)
+   - Save the material
+
+2. **View the Video:**
+   - Navigate to the course learn page
+   - Select the chapter with the video material
+   - The video should display with controls
+   - Test playback functionality
+
+3. **Test Different Formats:**
+   - Try uploading different video formats (MP4, MOV, WebM)
+   - Verify each format plays correctly
+
+### Troubleshooting
+
+If videos don't display:
+1. Check browser console for errors
+2. Verify the storage symlink exists: `ls -la public/storage`
+3. Check file permissions on storage directory
+4. Ensure the video file was uploaded successfully
+5. Check PHP error logs for upload issues
+
+## Technical Notes
+
+- Videos are stored in `storage/app/public/materials/`
+- Accessible via URL: `/storage/materials/[filename]`
+- Maximum file size: 100MB (configurable in validation rules)
+- Video player uses HTML5 `<video>` element with fallback messages


### PR DESCRIPTION
Fix local video display on the learn page and support various video formats.

Previously, locally uploaded videos were not visible because the `file_path` stored in the database was not being converted into a full, accessible URL for the frontend. This PR introduces a `file_url` accessor in the backend model and updates the frontend to correctly consume this URL, along with increasing PHP upload limits and ensuring the storage symlink is present to support larger video files and various formats like MP4, MOV, etc.

---
<a href="https://cursor.com/background-agent?bcId=bc-d10658b8-dfc5-483c-99a6-fca5f0f3c89d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d10658b8-dfc5-483c-99a6-fca5f0f3c89d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

