### PR TITLE
Flip payment gateway integration

### DIFF
--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -282,42 +282,94 @@ class PaymentController extends Controller
     {
         $billId = $request->query('bill_link_id') ?? $request->query('id');
         $courseId = $request->query('course_id');
+        $user = $request->user();
 
         Log::info('Flip callback received', [
             'bill_id' => $billId,
             'course_id' => $courseId,
+            'user_id' => $user?->id,
             'all_query' => $request->query(),
         ]);
 
+        $transaction = null;
+        $paymentCompleted = false;
+
         if ($billId) {
-            // Check bill status from Flip
+            // Check bill status from Flip API
             $statusInfo = $this->flip->getTransactionStatus($billId);
 
-            if ($statusInfo && $statusInfo['status'] === 'completed') {
-                $transaction = Transaction::where('flip_bill_id', $billId)->first();
-                if ($transaction) {
+            Log::info('Flip callback - bill status check', [
+                'bill_id' => $billId,
+                'status_info' => $statusInfo,
+            ]);
+
+            // Find the transaction
+            $transaction = Transaction::where('flip_bill_id', $billId)->first();
+
+            if ($transaction) {
+                // If status is completed (either from API check or already in DB)
+                if ($statusInfo && $statusInfo['status'] === 'completed') {
+                    $paymentCompleted = true;
                     $this->handlePaymentCompleted($transaction, $billId);
+                } elseif ($transaction->status === 'completed') {
+                    $paymentCompleted = true;
+                    // Trigger enrollment if not already done
+                    $this->autoEnrollUserToCourse($transaction);
                 }
             }
         }
 
-        // Redirect to payment page or course learn page
-        if ($courseId) {
-            // Check if user is enrolled
-            $user = $request->user();
-            if ($user) {
+        // Determine redirect based on payment status
+        if ($user) {
+            // Get course ID from transaction if not in query
+            if (!$courseId && $transaction && $transaction->transactionable_type === Course::class) {
+                $courseId = $transaction->transactionable_id;
+            }
+
+            if ($courseId) {
+                // Check if user is enrolled
                 $isEnrolled = Enrollment::where('user_id', $user->id)
                     ->where('course_id', $courseId)
                     ->exists();
 
                 if ($isEnrolled) {
+                    Log::info('Flip callback - user enrolled, redirecting to learn page', [
+                        'user_id' => $user->id,
+                        'course_id' => $courseId,
+                    ]);
+
                     return redirect()->route('courses.learn', $courseId)
                         ->with('success', 'Pembayaran berhasil! Anda sudah terdaftar di kursus.');
                 }
-            }
 
-            return redirect()->route('payments.show', $courseId)
-                ->with('info', 'Memproses pembayaran...');
+                // Payment completed but not enrolled yet - try to enroll again
+                if ($paymentCompleted && $transaction) {
+                    Log::info('Flip callback - payment completed but not enrolled, retrying enrollment', [
+                        'user_id' => $user->id,
+                        'course_id' => $courseId,
+                        'transaction_id' => $transaction->id,
+                    ]);
+
+                    $this->autoEnrollUserToCourse($transaction);
+
+                    // Check enrollment again
+                    $isEnrolled = Enrollment::where('user_id', $user->id)
+                        ->where('course_id', $courseId)
+                        ->exists();
+
+                    if ($isEnrolled) {
+                        return redirect()->route('courses.learn', $courseId)
+                            ->with('success', 'Pembayaran berhasil! Anda sudah terdaftar di kursus.');
+                    }
+                }
+
+                // Redirect to payment page to show status
+                return redirect()->route('payments.show', $courseId)
+                    ->with($paymentCompleted ? 'success' : 'info',
+                        $paymentCompleted
+                            ? 'Pembayaran berhasil! Memproses pendaftaran kursus...'
+                            : 'Memproses pembayaran...');
+            }
         }
 
         return redirect()->route('home');
@@ -502,7 +554,7 @@ class PaymentController extends Controller
     /**
      * Show Flip payment page
      */
-    private function showFlipPaymentPage(Request $request, Course $course, $user, ?Transaction $pendingTransaction): Response
+    private function showFlipPaymentPage(Request $request, Course $course, $user, ?Transaction $pendingTransaction): Response|RedirectResponse
     {
         try {
             $result = $this->flip->createCourseTransaction($user, $course);
@@ -512,7 +564,39 @@ class PaymentController extends Controller
                 'course_id' => $course->id,
                 'bill_id' => $result['bill_id'],
                 'is_existing' => $result['is_existing'] ?? false,
+                'is_completed' => $result['is_completed'] ?? false,
             ]);
+
+            // Handle case when transaction is already completed
+            if ($result['is_completed'] ?? false) {
+                // Trigger auto-enrollment
+                $this->autoEnrollUserToCourse($result['transaction']);
+
+                // Check if user is now enrolled
+                $isEnrolled = Enrollment::where('user_id', $user->id)
+                    ->where('course_id', $course->id)
+                    ->exists();
+
+                if ($isEnrolled) {
+                    return redirect()->route('courses.learn', $course->id)
+                        ->with('success', 'Pembayaran sudah selesai! Anda sudah terdaftar di kursus.');
+                }
+
+                // Payment completed but enrollment might still be processing
+                return Inertia::render('payment/index', [
+                    'course' => $course,
+                    'transaction' => $result['transaction'],
+                    'snapToken' => null,
+                    'paymentUrl' => null,
+                    'billId' => $result['bill_id'],
+                    'clientKey' => null,
+                    'isProduction' => (bool) config('flip.is_production'),
+                    'isAlreadyEnrolled' => false,
+                    'isAlreadyPaid' => true,
+                    'transactionExpired' => false,
+                    'defaultGateway' => 'flip',
+                ]);
+            }
 
             return Inertia::render('payment/index', [
                 'course' => $course,

--- a/app/Services/FlipService.php
+++ b/app/Services/FlipService.php
@@ -33,12 +33,12 @@ class FlipService
      */
     public function createCourseTransaction(User $user, Course $course): array
     {
-        // Check for existing pending transaction
+        // Check for existing transaction (pending, processing, or completed)
         $existingTransaction = Transaction::where('user_id', $user->id)
             ->where('transactionable_id', $course->id)
             ->where('transactionable_type', Course::class)
             ->where('payment_gateway', 'flip')
-            ->whereIn('status', ['pending', 'processing'])
+            ->whereIn('status', ['pending', 'processing', 'completed'])
             ->orderBy('created_at', 'desc')
             ->first();
 
@@ -47,12 +47,57 @@ class FlipService
                 'flip_bill_id' => $existingTransaction->flip_bill_id,
                 'user_id' => $user->id,
                 'course_id' => $course->id,
+                'current_status' => $existingTransaction->status,
             ]);
+
+            // If transaction is already completed, return it immediately
+            if ($existingTransaction->status === 'completed') {
+                Log::info('Existing Flip transaction already completed', [
+                    'flip_bill_id' => $existingTransaction->flip_bill_id,
+                ]);
+
+                return [
+                    'bill_id' => $existingTransaction->flip_bill_id,
+                    'payment_url' => null,
+                    'transaction' => $existingTransaction,
+                    'is_existing' => true,
+                    'is_completed' => true,
+                ];
+            }
 
             // Check if bill is still valid with Flip API
             $billStatus = $this->getBillStatus($existingTransaction->flip_bill_id);
+            $flipStatus = strtoupper($billStatus['status'] ?? '');
 
-            if ($billStatus && in_array(strtoupper($billStatus['status'] ?? ''), ['PENDING', 'ACTIVE'])) {
+            // Handle SUCCESSFUL/PAID/DONE status - payment was completed!
+            if ($billStatus && in_array($flipStatus, ['SUCCESSFUL', 'DONE', 'PAID'])) {
+                Log::info('Flip bill is already paid, updating transaction to completed', [
+                    'flip_bill_id' => $existingTransaction->flip_bill_id,
+                    'flip_status' => $flipStatus,
+                ]);
+
+                $details = $existingTransaction->payment_details ?? [];
+                $details['completed_from_api_check'] = true;
+                $details['completed_at'] = now()->toISOString();
+                $details['flip_final_status'] = $billStatus;
+
+                $existingTransaction->update([
+                    'status' => 'completed',
+                    'payment_details' => $details,
+                    'payment_method' => $billStatus['sender_bank'] ?? $billStatus['payment_method'] ?? $existingTransaction->payment_method,
+                ]);
+
+                return [
+                    'bill_id' => $existingTransaction->flip_bill_id,
+                    'payment_url' => null,
+                    'transaction' => $existingTransaction->fresh(),
+                    'is_existing' => true,
+                    'is_completed' => true,
+                ];
+            }
+
+            // Handle PENDING/ACTIVE status - bill is still valid for payment
+            if ($billStatus && in_array($flipStatus, ['PENDING', 'ACTIVE', 'NOT_CONFIRMED'])) {
                 // Get payment URL from bill status or existing transaction
                 $paymentUrl = $billStatus['link_url'] ?? $existingTransaction->payment_details['payment_url'] ?? null;
 
@@ -82,12 +127,30 @@ class FlipService
                 ];
             }
 
-            // Bill expired or invalid, mark as expired
-            Log::info('Existing Flip transaction is no longer valid, marking as expired', [
-                'flip_bill_id' => $existingTransaction->flip_bill_id,
-                'bill_status' => $billStatus['status'] ?? 'unknown',
-            ]);
-            $existingTransaction->update(['status' => 'expired']);
+            // Bill is truly expired/cancelled/failed - mark as expired
+            if ($billStatus && in_array($flipStatus, ['EXPIRED', 'INACTIVE', 'CANCELLED', 'CANCELED', 'FAILED'])) {
+                Log::info('Existing Flip transaction is expired/cancelled, marking as expired', [
+                    'flip_bill_id' => $existingTransaction->flip_bill_id,
+                    'bill_status' => $flipStatus,
+                ]);
+                $existingTransaction->update(['status' => 'expired']);
+            } elseif (!$billStatus) {
+                // Could not get bill status - might be network issue, keep transaction as is
+                Log::warning('Could not get Flip bill status, keeping existing transaction', [
+                    'flip_bill_id' => $existingTransaction->flip_bill_id,
+                ]);
+
+                // Try to use existing payment URL
+                $paymentUrl = $existingTransaction->payment_details['payment_url'] ?? null;
+                if ($paymentUrl) {
+                    return [
+                        'bill_id' => $existingTransaction->flip_bill_id,
+                        'payment_url' => $paymentUrl,
+                        'transaction' => $existingTransaction,
+                        'is_existing' => true,
+                    ];
+                }
+            }
         }
 
         // Create new bill

--- a/resources/js/pages/payment/index.tsx
+++ b/resources/js/pages/payment/index.tsx
@@ -689,6 +689,43 @@ const PaymentPage: React.FC = () => {
     } = props;
     const userId = props.auth.user.id;
 
+    // Auto-redirect when already paid - verify enrollment and redirect
+    useEffect(() => {
+        if (isAlreadyPaid && initialTransaction) {
+            const orderId = initialTransaction.flip_bill_id || initialTransaction.midtrans_order_id;
+            if (!orderId) return;
+
+            console.log('[PaymentPage] Already paid, verifying enrollment...');
+
+            // Call verify and enroll endpoint
+            fetch(`/payments/${orderId}/verify-and-enroll`, {
+                method: 'POST',
+                headers: {
+                    Accept: 'application/json',
+                    'Content-Type': 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-TOKEN': (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.getAttribute('content') || '',
+                },
+                credentials: 'include',
+            })
+                .then((res) => res.json())
+                .then((data) => {
+                    console.log('[PaymentPage] Verify enrollment response:', data);
+                    if (data.enrolled && data.redirect_url) {
+                        window.location.href = data.redirect_url;
+                    } else if (data.success) {
+                        // Payment completed, try redirecting to learn page
+                        setTimeout(() => {
+                            router.visit(`/courses/${course.id}/learn`);
+                        }, 1500);
+                    }
+                })
+                .catch((err) => {
+                    console.error('[PaymentPage] Error verifying enrollment:', err);
+                });
+        }
+    }, [isAlreadyPaid, initialTransaction, course.id]);
+
     const payment = usePaymentTransaction({
         userId,
         course,
@@ -735,7 +772,24 @@ const PaymentPage: React.FC = () => {
 
             {initError && <div className="rounded bg-red-100 p-3 text-red-700">{initError}</div>}
             {isAlreadyEnrolled && <div className="rounded bg-green-100 p-3 text-green-700">Anda sudah terdaftar.</div>}
-            {isAlreadyPaid && <div className="rounded bg-green-100 p-3 text-green-700">Pembayaran sudah selesai.</div>}
+            {isAlreadyPaid && (
+                <div className="rounded-lg bg-green-100 p-4 text-green-700">
+                    <div className="flex items-center gap-3">
+                        <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path
+                                className="opacity-75"
+                                fill="currentColor"
+                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                            ></path>
+                        </svg>
+                        <div>
+                            <span className="font-medium">Pembayaran sudah selesai!</span>
+                            <p className="text-sm">Memproses pendaftaran kursus, mohon tunggu...</p>
+                        </div>
+                    </div>
+                </div>
+            )}
             {transactionExpired && (
                 <div className="rounded bg-yellow-100 p-3 text-yellow-800">{expiredMessage || 'Transaksi sebelumnya telah kedaluwarsa.'}</div>
             )}


### PR DESCRIPTION
Fix Flip payment integration to correctly handle successful payments, auto-enroll users, and redirect to the course learn page.

Previously, the system incorrectly marked successful Flip transactions as 'expired' because `FlipService` only recognized 'PENDING' or 'ACTIVE' statuses as valid. This prevented proper enrollment and redirection after payment, leading to a "kadaluarsa" message on the payment page even after a successful transaction.

---
<a href="https://cursor.com/background-agent?bcId=bc-bfa6dc74-4c76-4223-9e17-dca338f70cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bfa6dc74-4c76-4223-9e17-dca338f70cb0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

