### PR TITLE
Flip payment transaction error

### DIFF
--- a/app/Console/Commands/RepairTransactionsTable.php
+++ b/app/Console/Commands/RepairTransactionsTable.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class RepairTransactionsTable extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'transactions:repair
+                            {--diagnose : Only diagnose, don\'t fix}
+                            {--force : Skip confirmation}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Diagnose and repair the transactions table (fixes auto-increment issues)';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('🔍 Diagnosing transactions table...');
+        $this->newLine();
+
+        // 1. Check table existence
+        if (!Schema::hasTable('transactions')) {
+            $this->error('❌ Table "transactions" does not exist!');
+            return 1;
+        }
+        $this->info('✅ Table "transactions" exists');
+
+        // 2. Get table status
+        $tableStatus = DB::selectOne("SHOW TABLE STATUS LIKE 'transactions'");
+        
+        if (!$tableStatus) {
+            $this->error('❌ Could not get table status');
+            return 1;
+        }
+
+        $this->table(
+            ['Property', 'Value'],
+            [
+                ['Engine', $tableStatus->Engine ?? 'N/A'],
+                ['Rows (approx)', $tableStatus->Rows ?? 'N/A'],
+                ['Auto_increment', $tableStatus->Auto_increment ?? 'NULL'],
+                ['Data_length', $this->formatBytes($tableStatus->Data_length ?? 0)],
+                ['Index_length', $this->formatBytes($tableStatus->Index_length ?? 0)],
+            ]
+        );
+        $this->newLine();
+
+        // 3. Check current max ID
+        $maxId = DB::selectOne("SELECT MAX(id) as max_id FROM transactions");
+        $currentMaxId = $maxId->max_id ?? 0;
+        $this->info("📊 Current MAX(id): " . ($currentMaxId ?: 'No records'));
+
+        // 4. Check auto_increment value
+        $currentAutoIncrement = $tableStatus->Auto_increment ?? null;
+        $this->info("📊 Current AUTO_INCREMENT: " . ($currentAutoIncrement ?: 'NULL/Unknown'));
+
+        // 5. Identify issues
+        $issues = [];
+        
+        if ($currentAutoIncrement === null) {
+            $issues[] = 'AUTO_INCREMENT value is NULL or corrupted';
+        } elseif ($currentMaxId > 0 && $currentAutoIncrement <= $currentMaxId) {
+            $issues[] = "AUTO_INCREMENT ($currentAutoIncrement) is less than or equal to MAX(id) ($currentMaxId)";
+        }
+
+        // 6. Check for virtual columns
+        $columns = DB::select("SHOW COLUMNS FROM transactions");
+        $virtualColumns = [];
+        foreach ($columns as $column) {
+            if (isset($column->Extra) && str_contains(strtolower($column->Extra), 'virtual')) {
+                $virtualColumns[] = $column->Field;
+            }
+        }
+        
+        if (!empty($virtualColumns)) {
+            $this->warn('⚠️  Virtual columns detected: ' . implode(', ', $virtualColumns));
+            $this->info('   (Virtual columns can sometimes cause auto-increment issues in MySQL)');
+        }
+
+        // 7. Check for indexes
+        $this->newLine();
+        $this->info('📋 Indexes on transactions table:');
+        $indexes = DB::select("SHOW INDEX FROM transactions");
+        $indexInfo = [];
+        foreach ($indexes as $index) {
+            $indexInfo[] = [
+                'Name' => $index->Key_name,
+                'Column' => $index->Column_name,
+                'Unique' => $index->Non_unique ? 'No' : 'Yes',
+            ];
+        }
+        $this->table(['Name', 'Column', 'Unique'], $indexInfo);
+
+        $this->newLine();
+
+        if (empty($issues)) {
+            $this->info('✅ No obvious issues detected with AUTO_INCREMENT');
+            
+            if ($this->option('diagnose')) {
+                return 0;
+            }
+            
+            if (!$this->option('force') && !$this->confirm('Would you like to repair/optimize the table anyway?')) {
+                return 0;
+            }
+        } else {
+            $this->newLine();
+            $this->error('❌ Issues detected:');
+            foreach ($issues as $issue) {
+                $this->line("   - $issue");
+            }
+        }
+
+        if ($this->option('diagnose')) {
+            $this->newLine();
+            $this->warn('Diagnose mode - no changes made. Run without --diagnose to fix issues.');
+            return 0;
+        }
+
+        if (!$this->option('force') && !$this->confirm('Do you want to repair the table?')) {
+            $this->info('Cancelled.');
+            return 0;
+        }
+
+        // Perform repairs
+        $this->newLine();
+        $this->info('🔧 Repairing transactions table...');
+
+        // Step 1: Calculate correct auto_increment
+        $newAutoIncrement = max(1, ($currentMaxId ?? 0) + 1);
+        $this->info("   Setting AUTO_INCREMENT to: $newAutoIncrement");
+
+        try {
+            // Reset auto_increment
+            DB::statement("ALTER TABLE transactions AUTO_INCREMENT = $newAutoIncrement");
+            $this->info('   ✅ AUTO_INCREMENT reset successfully');
+        } catch (\Exception $e) {
+            $this->error('   ❌ Failed to reset AUTO_INCREMENT: ' . $e->getMessage());
+        }
+
+        // Step 2: Analyze table
+        $this->info('   Running ANALYZE TABLE...');
+        try {
+            DB::statement("ANALYZE TABLE transactions");
+            $this->info('   ✅ ANALYZE TABLE completed');
+        } catch (\Exception $e) {
+            $this->warn('   ⚠️  ANALYZE TABLE failed: ' . $e->getMessage());
+        }
+
+        // Step 3: Optimize table (optional, can help with fragmentation)
+        $this->info('   Running OPTIMIZE TABLE (this may take a moment)...');
+        try {
+            DB::statement("OPTIMIZE TABLE transactions");
+            $this->info('   ✅ OPTIMIZE TABLE completed');
+        } catch (\Exception $e) {
+            $this->warn('   ⚠️  OPTIMIZE TABLE failed: ' . $e->getMessage());
+        }
+
+        // Verify the fix
+        $this->newLine();
+        $this->info('🔍 Verifying repair...');
+        
+        $newTableStatus = DB::selectOne("SHOW TABLE STATUS LIKE 'transactions'");
+        $this->table(
+            ['Property', 'Before', 'After'],
+            [
+                ['Auto_increment', $currentAutoIncrement ?? 'NULL', $newTableStatus->Auto_increment ?? 'NULL'],
+            ]
+        );
+
+        $this->newLine();
+        $this->info('✅ Repair completed!');
+        $this->info('   You can now try creating a new transaction.');
+
+        return 0;
+    }
+
+    /**
+     * Format bytes to human readable format
+     */
+    private function formatBytes($bytes): string
+    {
+        if ($bytes >= 1073741824) {
+            return number_format($bytes / 1073741824, 2) . ' GB';
+        } elseif ($bytes >= 1048576) {
+            return number_format($bytes / 1048576, 2) . ' MB';
+        } elseif ($bytes >= 1024) {
+            return number_format($bytes / 1024, 2) . ' KB';
+        } else {
+            return $bytes . ' bytes';
+        }
+    }
+}

--- a/app/Services/FlipService.php
+++ b/app/Services/FlipService.php
@@ -5,6 +5,7 @@ namespace App\Services;
 use App\Models\Course;
 use App\Models\Transaction;
 use App\Models\User;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -248,88 +249,175 @@ class FlipService
         // Convert link_id to string for storage
         $billId = isset($billData['link_id']) ? (string) $billData['link_id'] : ($billData['bill_link_id'] ?? null);
 
-        // Check if there's an existing transaction with this flip_bill_id
-        // This can happen if Flip returns the same bill for subsequent requests
-        // or if a previous transaction was marked as expired/cancelled but the bill is still valid
-        $existingByBillId = Transaction::where('flip_bill_id', $billId)->first();
+        // Wrap database operations in a transaction with retry logic to handle
+        // auto-increment issues and race conditions
+        $maxRetries = 3;
+        $attempt = 0;
+        $lastException = null;
 
-        if ($existingByBillId) {
-            Log::info('Found existing transaction with same flip_bill_id, updating instead of creating', [
-                'flip_bill_id' => $billId,
-                'existing_status' => $existingByBillId->status,
-                'user_id' => $user->id,
-                'course_id' => $course->id,
-            ]);
+        while ($attempt < $maxRetries) {
+            $attempt++;
+            
+            try {
+                return DB::transaction(function () use ($user, $course, $billId, $billData, $paymentUrl) {
+                    // Check if there's an existing transaction with this flip_bill_id
+                    // Use lockForUpdate to prevent race conditions
+                    $existingByBillId = Transaction::where('flip_bill_id', $billId)
+                        ->lockForUpdate()
+                        ->first();
 
-            // Update the existing transaction with new data
-            $existingByBillId->update([
-                'user_id' => $user->id,
-                'transactionable_id' => $course->id,
-                'transactionable_type' => Course::class,
-                'payment_gateway' => 'flip',
-                'amount' => (int) $course->price,
-                'status' => 'pending',
-                'payment_details' => [
-                    'flip_response' => $billData,
-                    'payment_url' => $paymentUrl,
-                    'bill_link' => $paymentUrl,
-                    'title' => $billData['title'] ?? null,
-                    'created_at' => now()->toISOString(),
-                    'reactivated_from' => $existingByBillId->status,
-                    'reactivated_at' => now()->toISOString(),
-                ],
-            ]);
+                    if ($existingByBillId) {
+                        Log::info('Found existing transaction with same flip_bill_id, updating instead of creating', [
+                            'flip_bill_id' => $billId,
+                            'existing_status' => $existingByBillId->status,
+                            'user_id' => $user->id,
+                            'course_id' => $course->id,
+                        ]);
 
-            Log::info('Updated existing Flip transaction', [
-                'transaction_id' => $existingByBillId->id,
-                'flip_bill_id' => $billId,
-                'user_id' => $user->id,
-                'course_id' => $course->id,
-                'payment_url' => $paymentUrl,
-            ]);
+                        // Update the existing transaction with new data
+                        $existingByBillId->update([
+                            'user_id' => $user->id,
+                            'transactionable_id' => $course->id,
+                            'transactionable_type' => Course::class,
+                            'payment_gateway' => 'flip',
+                            'amount' => (int) $course->price,
+                            'status' => 'pending',
+                            'payment_details' => [
+                                'flip_response' => $billData,
+                                'payment_url' => $paymentUrl,
+                                'bill_link' => $paymentUrl,
+                                'title' => $billData['title'] ?? null,
+                                'created_at' => now()->toISOString(),
+                                'reactivated_from' => $existingByBillId->status,
+                                'reactivated_at' => now()->toISOString(),
+                            ],
+                        ]);
 
-            return [
-                'bill_id' => $billId,
-                'payment_url' => $paymentUrl,
-                'transaction' => $existingByBillId->fresh(),
-                'is_existing' => true,
-            ];
+                        Log::info('Updated existing Flip transaction', [
+                            'transaction_id' => $existingByBillId->id,
+                            'flip_bill_id' => $billId,
+                            'user_id' => $user->id,
+                            'course_id' => $course->id,
+                            'payment_url' => $paymentUrl,
+                        ]);
+
+                        return [
+                            'bill_id' => $billId,
+                            'payment_url' => $paymentUrl,
+                            'transaction' => $existingByBillId->fresh(),
+                            'is_existing' => true,
+                        ];
+                    }
+
+                    // Create new transaction record
+                    $transaction = Transaction::create([
+                        'user_id' => $user->id,
+                        'transactionable_id' => $course->id,
+                        'transactionable_type' => Course::class,
+                        'flip_bill_id' => $billId,
+                        'midtrans_order_id' => null, // Not using Midtrans
+                        'payment_gateway' => 'flip',
+                        'amount' => (int) $course->price,
+                        'payment_method' => null, // Will be filled after user selects
+                        'status' => 'pending',
+                        'payment_details' => [
+                            'flip_response' => $billData,
+                            'payment_url' => $paymentUrl,
+                            'bill_link' => $paymentUrl,
+                            'title' => $billData['title'] ?? null,
+                            'created_at' => now()->toISOString(),
+                        ],
+                    ]);
+
+                    Log::info('Created new Flip transaction', [
+                        'transaction_id' => $transaction->id,
+                        'flip_bill_id' => $transaction->flip_bill_id,
+                        'user_id' => $user->id,
+                        'course_id' => $course->id,
+                        'payment_url' => $paymentUrl,
+                    ]);
+
+                    return [
+                        'bill_id' => $transaction->flip_bill_id,
+                        'payment_url' => $paymentUrl,
+                        'transaction' => $transaction,
+                        'is_existing' => false,
+                    ];
+                });
+            } catch (\Illuminate\Database\QueryException $e) {
+                $lastException = $e;
+                
+                // Check if it's an auto-increment error (1467) or duplicate entry error (1062)
+                $errorCode = $e->errorInfo[1] ?? 0;
+                
+                Log::warning('Database error during Flip transaction creation, attempt ' . $attempt, [
+                    'error_code' => $errorCode,
+                    'error_message' => $e->getMessage(),
+                    'user_id' => $user->id,
+                    'course_id' => $course->id,
+                    'flip_bill_id' => $billId,
+                    'attempt' => $attempt,
+                ]);
+
+                // For auto-increment error (1467), try to repair and retry
+                if ($errorCode === 1467 && $attempt < $maxRetries) {
+                    $this->repairAutoIncrement();
+                    usleep(100000); // Wait 100ms before retry
+                    continue;
+                }
+
+                // For duplicate entry (1062), try to find and return existing
+                if ($errorCode === 1062) {
+                    $existingTransaction = Transaction::where('flip_bill_id', $billId)->first();
+                    if ($existingTransaction) {
+                        Log::info('Found existing transaction after duplicate key error', [
+                            'transaction_id' => $existingTransaction->id,
+                            'flip_bill_id' => $billId,
+                        ]);
+                        
+                        return [
+                            'bill_id' => $billId,
+                            'payment_url' => $existingTransaction->payment_details['payment_url'] ?? $paymentUrl,
+                            'transaction' => $existingTransaction,
+                            'is_existing' => true,
+                        ];
+                    }
+                }
+
+                // For other errors or max retries reached, throw
+                if ($attempt >= $maxRetries) {
+                    throw $e;
+                }
+                
+                usleep(100000); // Wait 100ms before retry
+            }
         }
 
-        // Create new transaction record
-        $transaction = Transaction::create([
-            'user_id' => $user->id,
-            'transactionable_id' => $course->id,
-            'transactionable_type' => Course::class,
-            'flip_bill_id' => $billId,
-            'midtrans_order_id' => null, // Not using Midtrans
-            'payment_gateway' => 'flip',
-            'amount' => (int) $course->price,
-            'payment_method' => null, // Will be filled after user selects
-            'status' => 'pending',
-            'payment_details' => [
-                'flip_response' => $billData,
-                'payment_url' => $paymentUrl,
-                'bill_link' => $paymentUrl,
-                'title' => $billData['title'] ?? null,
-                'created_at' => now()->toISOString(),
-            ],
-        ]);
+        // If we get here, all retries failed
+        throw $lastException ?? new \Exception('Failed to create transaction after ' . $maxRetries . ' attempts');
+    }
 
-        Log::info('Created new Flip transaction', [
-            'transaction_id' => $transaction->id,
-            'flip_bill_id' => $transaction->flip_bill_id,
-            'user_id' => $user->id,
-            'course_id' => $course->id,
-            'payment_url' => $paymentUrl,
-        ]);
-
-        return [
-            'bill_id' => $transaction->flip_bill_id,
-            'payment_url' => $paymentUrl,
-            'transaction' => $transaction,
-            'is_existing' => false,
-        ];
+    /**
+     * Attempt to repair auto-increment value for transactions table
+     */
+    private function repairAutoIncrement(): void
+    {
+        try {
+            $maxId = DB::selectOne("SELECT MAX(id) as max_id FROM transactions");
+            $newAutoIncrement = max(1, (int) ($maxId->max_id ?? 0) + 1);
+            
+            // MySQL doesn't support placeholders for ALTER TABLE, so we use
+            // intval to ensure it's a safe integer value
+            DB::statement("ALTER TABLE transactions AUTO_INCREMENT = " . $newAutoIncrement);
+            
+            Log::info('Auto-increment repaired for transactions table', [
+                'new_auto_increment' => $newAutoIncrement,
+            ]);
+        } catch (\Exception $e) {
+            Log::error('Failed to repair auto-increment', [
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix `SQLSTATE[HY000]: General error: 1467` on `transactions` table by adding retry logic with auto-repair in `FlipService` and a dedicated `transactions:repair` Artisan command.

The `1467 Failed to read auto-increment value` error indicates a corrupted auto-increment counter in the `transactions` table, often exacerbated by virtual columns or race conditions during concurrent inserts. This PR addresses the issue by automatically repairing the auto-increment value, retrying failed transactions, and providing a manual repair command.

---
<a href="https://cursor.com/background-agent?bcId=bc-0f3fa242-17dd-4dfb-8604-5b0331f0cd86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0f3fa242-17dd-4dfb-8604-5b0331f0cd86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

